### PR TITLE
Fix error when passing json file with encapsulated string

### DIFF
--- a/src/SbSOvRL/util/reward_helpers.py
+++ b/src/SbSOvRL/util/reward_helpers.py
@@ -73,7 +73,7 @@ def spor_com_additional_information(j_str: str) -> Dict[str, Any]:
     Returns:
         Dict[str, Any]: Dict created from the json definition
     """
-    a = json.loads(j_str)
+    a = json.loads(j_str[1:-1])
     return a
 
 


### PR DESCRIPTION
@clemens-fricke this should be working now, feel free to merge. In the future we might want to find the root of this encapsulated string problem and if possible fix it there.