### PR TITLE
Fix: docs build agent

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.12"
+    python: "3.10"
   jobs:
     pre_build:
       - python3 schema.py


### PR DESCRIPTION
Another error...

Moved build python version to 3.10 instead of 3.12.