### PR TITLE
ci: update version of github artifacts to build and upload to v4

### DIFF
--- a/.github/workflows/build_and_upload_wheels.yml
+++ b/.github/workflows/build_and_upload_wheels.yml
@@ -13,7 +13,7 @@ jobs:
       - name: build wheels and sdist
         run: pipx run build
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: ./dist/*
 
@@ -21,7 +21,7 @@ jobs:
     needs: [wheel_build_full]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: artifact
           path: dist


### PR DESCRIPTION
Update artifacts from v3 to v4 for the build and upload to pypi.