### PR TITLE
Visualization of episode_log

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,9 @@ docs = [
     "sphinx-rtd-theme",
     "sphinx-jsonschema",
 ]
+visualize = [
+    "plotly",
+]
 dev = [
     "splinepy[all]>=0.1.2",
     "torchvision",
@@ -60,6 +63,7 @@ dev = [
     "sphinx",
     "sphinx-rtd-theme",
     "sphinx-jsonschema",
+    "plotly",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ docs = [
 ]
 visualize = [
     "plotly",
+    "kaleido",
 ]
 dev = [
     "splinepy[all]>=0.1.2",
@@ -64,6 +65,7 @@ dev = [
     "sphinx-rtd-theme",
     "sphinx-jsonschema",
     "plotly",
+    "kaleido",
 ]
 
 [project.scripts]

--- a/releso/__main__.py
+++ b/releso/__main__.py
@@ -250,11 +250,15 @@ def entry():
         if run_folder is not None:
             folders_to_process.append(run_folder)
         folder_dict = {folder.stem: folder for folder in folders_to_process}
+
+        figure_size = args.figure_size
+        if len(figure_size) == 1:
+            figure_size = figure_size[0]
         plot_episode_log(
             folder_dict,
             args.export_path,
             args.window,
-            window_size=args.figure_size,
+            window_size=figure_size,
         )
 
 

--- a/releso/__version__.py
+++ b/releso/__version__.py
@@ -2,4 +2,5 @@
 
 Current version.
 """
-__version__ = "0.1.3"
+
+__version__ = "0.1.3.dev1"

--- a/releso/util/visualization.py
+++ b/releso/util/visualization.py
@@ -1,0 +1,200 @@
+import pathlib
+
+import pandas as pd
+from pandas.errors import EmptyDataError
+
+from releso.util.module_import_raiser import ModuleImportRaiser
+
+try:
+    import plotly.graph_objects as go
+    from plotly.subplots import make_subplots
+except ModuleNotFoundError:
+    go = ModuleImportRaiser("plotly")
+    make_subplots = ModuleImportRaiser("plotly")
+
+
+plotly_colors = [
+    "red",
+    "blue",
+    "green",
+    "orange",
+    "purple",
+    "brown",
+    "pink",
+    "gray",
+    "olive",
+    "cyan",
+]
+plotly_lines = ["solid", "dash", "dot", "dashdot"]
+
+
+def plot_episode_log(
+    result_folders: dict[str, pathlib.Path],
+    export_path: pathlib.Path,
+    window: int = 5,
+):
+    end_episode = []
+
+    cut_off_point = 350000
+    df: list[pd.DataFrame] = []
+    n_env: list[str] = list(result_folders.keys())
+    unique_values = set()
+    for idx, folder in enumerate(result_folders.values()):
+        try:
+            temp_df = pd.read_csv(folder / "episode_log.csv", index_col=0)
+        except EmptyDataError as err:
+            print(
+                f"Error occured with data in folder {folder}. The error is {err}"
+            )
+            continue
+        end_episode.append(
+            (temp_df.loc[temp_df["total_timesteps"] < cut_off_point].index)[-1]
+        )
+        row = pd.to_datetime(temp_df["wall_time"])
+        temp_df["wall_time"] = row
+        temp_df["run_time"] = row - row.iloc[0]
+        temp_df["time_delta"] = row - row.shift()
+        temp_df["mean_step_reward"] = (
+            temp_df["episode_reward"] / temp_df["steps_in_episode"]
+        )
+        unique_values.update(temp_df["episode_end_reason"].unique())
+        df.append(temp_df)
+
+    fig = make_subplots(
+        rows=6, cols=1, shared_xaxes=True, vertical_spacing=0.01
+    )
+    first_run = True
+    for idx, dataframe in enumerate(df):
+        print(idx)
+        fig.add_trace(
+            go.Scatter(
+                x=dataframe["total_timesteps"].iloc[: end_episode[idx]],
+                y=dataframe["episode_reward"]
+                .iloc[: end_episode[idx]]
+                .rolling(window, window)
+                .mean(),
+                mode="lines",
+                name=f"{n_env[idx]}",
+                legendgroup="Tests",
+                legendgrouptitle=dict(text="Tests"),
+                line=dict(color=plotly_colors[idx]),
+                showlegend=True,
+            ),
+            row=1,
+            col=1,
+        )
+        fig.add_trace(
+            go.Scatter(
+                x=dataframe["total_timesteps"].iloc[: end_episode[idx]],
+                y=dataframe["steps_in_episode"]
+                .iloc[: end_episode[idx]]
+                .rolling(window, window)
+                .mean(),
+                mode="lines",
+                name=f"{n_env[idx]}",
+                legendgroup="Tests",
+                line=dict(color=plotly_colors[idx]),
+                showlegend=False,
+            ),
+            row=2,
+            col=1,
+        )
+        fig.add_trace(
+            go.Scatter(
+                x=dataframe["total_timesteps"].iloc[: end_episode[idx]],
+                y=dataframe["mean_step_reward"]
+                .iloc[: end_episode[idx]]
+                .rolling(window, window)
+                .mean(),
+                mode="lines",
+                name=f"{n_env[idx]}",
+                legendgroup="Tests",
+                line=dict(color=plotly_colors[idx]),
+                showlegend=False,
+            ),
+            row=3,
+            col=1,
+        )
+        for marker, unique_key in zip(plotly_lines, unique_values):
+            fig.add_trace(
+                go.Scatter(
+                    x=dataframe["total_timesteps"].iloc[: end_episode[idx]],
+                    y=(dataframe["episode_end_reason"] == unique_key)
+                    .iloc[: end_episode[idx]]
+                    .rolling(100, 0)
+                    .mean(),
+                    legendgroup="end_reason",
+                    legendgrouptitle=dict(text="Episode End Reasons"),
+                    name=f"{unique_key}",
+                    line=dict(
+                        color=plotly_colors[idx],
+                        dash=marker,
+                        width=4,
+                    ),
+                    showlegend=first_run,
+                ),
+                row=4,
+                col=1,
+            )
+        first_run = False
+        fig.add_trace(
+            go.Scatter(
+                x=dataframe["total_timesteps"].iloc[: end_episode[idx]],
+                y=dataframe["time_delta"]
+                .iloc[: end_episode[idx]]
+                .dt.total_seconds()
+                / dataframe["steps_in_episode"].iloc[: end_episode[idx]],
+                mode="lines",
+                name=f"{n_env[idx]}",
+                legendgroup="Tests",
+                line=dict(color=plotly_colors[idx]),
+                showlegend=False,
+            ),
+            row=5,
+            col=1,
+        )
+        fig.add_trace(
+            go.Scatter(
+                x=dataframe["total_timesteps"].iloc[: end_episode[idx]],
+                y=dataframe["run_time"].iloc[: end_episode[idx]],
+                mode="lines",
+                name=f"{n_env[idx]}",
+                legendgroup="Tests",
+                line=dict(color=plotly_colors[idx]),
+                showlegend=False,
+            ),
+            row=6,
+            col=1,
+        )
+
+        print(f"n_env[idx]: {n_env[idx]}")
+    fig.update_traces(line=dict(width=0.6))
+    fig.update_layout(height=800, width=1000)
+    fig.update_xaxes(title_text="Total time steps", row=6, col=1)
+    fig.update_yaxes(title_text="Episode reward", row=1, col=1)
+    fig.update_yaxes(title_text="Steps<br>per episode", row=2, col=1)
+    fig.update_yaxes(title_text="Mean step<br>reward", row=3, col=1)
+    fig.update_yaxes(title_text="Episode<br>end reason", row=4, col=1)
+    fig.update_yaxes(title_text="Seconds<br>per step [s]", row=5, col=1)
+    fig.update_yaxes(title_text="Wall time", row=6, col=1)
+
+    # Export the plot as html
+    suffix = export_path.suffix
+    if suffix == ".html":
+        fig.write_html(export_path)
+    elif suffix in ["png", "jpg", "jpeg", "webp", "svg", "pdf"]:
+        fig.write_image(export_path)
+    elif export_path.is_dir():
+        fig.write_html(export_path / "episode_log.html")
+    else:
+        if not (export_path.parent / "episode_log.html").exists():
+            print(
+                "File path suffix is not html nor is the file path a directory. "
+                f"Saving to {export_path.parent / 'episode_log.html'}"
+            )
+            fig.write_html(export_path.parent / "episode_log.html")
+        else:
+            print(
+                "File path suffix is not know nor is the file path a "
+                "directory. Not saving."
+            )

--- a/releso/util/visualization.py
+++ b/releso/util/visualization.py
@@ -91,7 +91,7 @@ def plot_episode_log(
             temp_df = pd.read_csv(folder / "episode_log.csv", index_col=0)
         except EmptyDataError as err:
             print(
-                f"Error occured with data in folder {folder}. The error is {err}"
+                f"Error occurred with data in folder {folder}. The error is {err}"
             )
             continue
         end_episode.append(
@@ -208,7 +208,10 @@ def plot_episode_log(
         fig.add_trace(
             go.Scatter(
                 x=dataframe["total_timesteps"].iloc[: end_episode[idx]],
-                y=dataframe["run_time"].iloc[: end_episode[idx]],
+                y=dataframe["run_time"]
+                .iloc[: end_episode[idx]]
+                .dt.total_seconds()
+                / 3600.0,
                 mode="lines",
                 legendgroup=f"{n_env[idx]}",
                 name=f"{n_env[idx]}",
@@ -253,7 +256,7 @@ def plot_episode_log(
     fig.update_yaxes(title_text="Mean step<br>reward", row=3, col=1)
     fig.update_yaxes(title_text="Episode<br>end reason", row=4, col=1)
     fig.update_yaxes(title_text="Seconds<br>per step [s]", row=5, col=1)
-    fig.update_yaxes(title_text="Wall time", row=6, col=1)
+    fig.update_yaxes(title_text="Wall time [h]", row=6, col=1)
 
     # Export the plot as the suffix or as "episode_log.html"
     suffix = export_path.suffix

--- a/releso/util/visualization.py
+++ b/releso/util/visualization.py
@@ -1,5 +1,7 @@
 import pathlib
+from typing import Literal, Union
 
+import numpy as np
 import pandas as pd
 from pandas.errors import EmptyDataError
 
@@ -32,10 +34,53 @@ def plot_episode_log(
     result_folders: dict[str, pathlib.Path],
     export_path: pathlib.Path,
     window: int = 5,
+    window_size: Union[tuple[int, int], Literal["auto"]] = "auto",
+    cut_off_point: int = np.iinfo(int).max,
 ):
-    end_episode = []
+    """Plot one or multiple episodes to check out the training progress.
 
-    cut_off_point = 350000
+    This function can already be called once the first results are in the
+     episode log file, to check out progress during training. But, in general,
+     this function is normally used to compare different runs to see
+     differences in the learning progress. In general all values are plotted
+     over the total number of steps taken during the training. The following
+     variables are shown:
+
+    1. Episode reward - Best used to see if the training is progressing
+    2. Steps per Episode - Here you can see if the number of steps to solve
+     the environment decreases over time.
+    3. Mean step reward - The higher the better each action actually is.
+     (Calculated value episode_reward/steps_per_episode)
+    4. Episode End Reason - For each run multiple lines to show why the
+     episode was terminated. !ATTENTION! the window here is 100 to calculate a
+     crude percentage.
+    5. Seconds per Step - Time each step took to compute. Should not have much
+     variation in general. But use case specific can have differences.
+    6. Wall time - How much time did elapse to this time step. (Integral of
+      previous plot).
+
+    To check out the training I like to look at all the plots at once to see if
+     there is anything that should concern me. For publishing most values have
+     no informational gain so feel free to adapt (Remove certain sub plot, etc)
+      the function.
+
+    Author: Clemens Fricke (clemens.david.fricke@tuwien.ac.at)
+
+    Args:
+        result_folders (dict[str, pathlib.Path]): Dict of name and path to each
+          experiment to visualize.
+        export_path (pathlib.Path): Path to export the visualization to. If
+          file name the suffix will be used to determine the file format. If a
+          folder is given a file 'episode_log.html' will be created.
+        window (int, optional): Windowing is used to smooth the plots.
+          Defaults to 5.
+        window_size (Union[tuple[int, int], Literal['auto']], optional): Size
+         of the figure used. For html 'auto' will adapt the size to the browser
+         or container size. Defaults to "auto".
+        cut_off_point (int, optional): Plot the episode only to a certain
+         number of time steps. Defaults to max int.
+    """
+    end_episode = []
     df: list[pd.DataFrame] = []
     n_env: list[str] = list(result_folders.keys())
     unique_values = set()
@@ -63,9 +108,7 @@ def plot_episode_log(
     fig = make_subplots(
         rows=6, cols=1, shared_xaxes=True, vertical_spacing=0.01
     )
-    first_run = True
     for idx, dataframe in enumerate(df):
-        print(idx)
         fig.add_trace(
             go.Scatter(
                 x=dataframe["total_timesteps"].iloc[: end_episode[idx]],
@@ -74,9 +117,8 @@ def plot_episode_log(
                 .rolling(window, window)
                 .mean(),
                 mode="lines",
+                legendgroup=f"{n_env[idx]}",
                 name=f"{n_env[idx]}",
-                legendgroup="Tests",
-                legendgrouptitle=dict(text="Tests"),
                 line=dict(color=plotly_colors[idx]),
                 showlegend=True,
             ),
@@ -91,8 +133,8 @@ def plot_episode_log(
                 .rolling(window, window)
                 .mean(),
                 mode="lines",
+                legendgroup=f"{n_env[idx]}",
                 name=f"{n_env[idx]}",
-                legendgroup="Tests",
                 line=dict(color=plotly_colors[idx]),
                 showlegend=False,
             ),
@@ -107,8 +149,8 @@ def plot_episode_log(
                 .rolling(window, window)
                 .mean(),
                 mode="lines",
+                legendgroup=f"{n_env[idx]}",
                 name=f"{n_env[idx]}",
-                legendgroup="Tests",
                 line=dict(color=plotly_colors[idx]),
                 showlegend=False,
             ),
@@ -123,20 +165,18 @@ def plot_episode_log(
                     .iloc[: end_episode[idx]]
                     .rolling(100, 0)
                     .mean(),
-                    legendgroup="end_reason",
-                    legendgrouptitle=dict(text="Episode End Reasons"),
-                    name=f"{unique_key}",
                     line=dict(
                         color=plotly_colors[idx],
                         dash=marker,
                         width=4,
                     ),
-                    showlegend=first_run,
+                    legendgroup=f"{n_env[idx]}",
+                    name=f"{unique_key}: {n_env[idx]}",
+                    showlegend=False,
                 ),
                 row=4,
                 col=1,
             )
-        first_run = False
         fig.add_trace(
             go.Scatter(
                 x=dataframe["total_timesteps"].iloc[: end_episode[idx]],
@@ -145,8 +185,8 @@ def plot_episode_log(
                 .dt.total_seconds()
                 / dataframe["steps_in_episode"].iloc[: end_episode[idx]],
                 mode="lines",
+                legendgroup=f"{n_env[idx]}",
                 name=f"{n_env[idx]}",
-                legendgroup="Tests",
                 line=dict(color=plotly_colors[idx]),
                 showlegend=False,
             ),
@@ -158,8 +198,8 @@ def plot_episode_log(
                 x=dataframe["total_timesteps"].iloc[: end_episode[idx]],
                 y=dataframe["run_time"].iloc[: end_episode[idx]],
                 mode="lines",
+                legendgroup=f"{n_env[idx]}",
                 name=f"{n_env[idx]}",
-                legendgroup="Tests",
                 line=dict(color=plotly_colors[idx]),
                 showlegend=False,
             ),
@@ -167,9 +207,31 @@ def plot_episode_log(
             col=1,
         )
 
-        print(f"n_env[idx]: {n_env[idx]}")
+    for marker, unique_key in zip(plotly_lines, unique_values):
+        fig.add_trace(
+            go.Scatter(
+                x=[None],
+                y=[None],
+                legendgroup="end_reason",
+                legendgrouptitle=dict(text="Episode End Reasons"),
+                name=f"{unique_key}",
+                line=dict(
+                    color="black",
+                    dash=marker,
+                    width=4,
+                ),
+                mode="lines",
+                showlegend=True,
+            ),
+            row=4,
+            col=1,
+        )
+
     fig.update_traces(line=dict(width=0.6))
-    fig.update_layout(height=800, width=1000)
+    if window_size[0] == "auto":
+        fig.update_layout(autosize=True)
+    else:
+        fig.update_layout(height=window_size[0], width=window_size[1])
     fig.update_xaxes(title_text="Total time steps", row=6, col=1)
     fig.update_yaxes(title_text="Episode reward", row=1, col=1)
     fig.update_yaxes(title_text="Steps<br>per episode", row=2, col=1)

--- a/releso/util/visualization.py
+++ b/releso/util/visualization.py
@@ -242,7 +242,7 @@ def plot_episode_log(
 
     # adapt figure size
     fig.update_traces(line=dict(width=0.6))
-    if window_size[0] == "auto":
+    if not isinstance(window_size, list) and window_size == "auto":
         fig.update_layout(autosize=True)
     else:
         fig.update_layout(height=window_size[0], width=window_size[1])

--- a/releso/util/visualization.py
+++ b/releso/util/visualization.py
@@ -259,7 +259,7 @@ def plot_episode_log(
     suffix = export_path.suffix
     if suffix == ".html":
         fig.write_html(export_path)
-    elif suffix in ["png", "jpg", "jpeg", "webp", "svg", "pdf"]:
+    elif suffix in [".png", ".jpg", ".jpeg", ".webp", ".svg", ".pdf"]:
         fig.write_image(export_path)
     elif export_path.is_dir():
         fig.write_html(export_path / "episode_log.html")

--- a/releso/util/visualization.py
+++ b/releso/util/visualization.py
@@ -82,7 +82,9 @@ def plot_episode_log(
     """
     end_episode = []
     df: list[pd.DataFrame] = []
+    # make a separate list for just the names of the experiments
     n_env: list[str] = list(result_folders.keys())
+    # set of all episode end reasons
     unique_values = set()
     for idx, folder in enumerate(result_folders.values()):
         try:
@@ -108,7 +110,10 @@ def plot_episode_log(
     fig = make_subplots(
         rows=6, cols=1, shared_xaxes=True, vertical_spacing=0.01
     )
+    # plot each experiment into each sub plot, the idx is used to determine the
+    # episode end and the episode name
     for idx, dataframe in enumerate(df):
+        # first subplot
         fig.add_trace(
             go.Scatter(
                 x=dataframe["total_timesteps"].iloc[: end_episode[idx]],
@@ -117,14 +122,15 @@ def plot_episode_log(
                 .rolling(window, window)
                 .mean(),
                 mode="lines",
-                legendgroup=f"{n_env[idx]}",
-                name=f"{n_env[idx]}",
+                legendgroup=f"{n_env[idx]}",  # Used so that each experiment can be disabled
+                name=f"{n_env[idx]}",  # name the legend item
                 line=dict(color=plotly_colors[idx]),
-                showlegend=True,
+                showlegend=True,  # show legend only for first subplot
             ),
             row=1,
             col=1,
         )
+        # second subplot
         fig.add_trace(
             go.Scatter(
                 x=dataframe["total_timesteps"].iloc[: end_episode[idx]],
@@ -141,6 +147,7 @@ def plot_episode_log(
             row=2,
             col=1,
         )
+        # third subplot
         fig.add_trace(
             go.Scatter(
                 x=dataframe["total_timesteps"].iloc[: end_episode[idx]],
@@ -157,10 +164,13 @@ def plot_episode_log(
             row=3,
             col=1,
         )
+        # fourth subplot - episode end reason iterate through all reasons
+        # legend for this plot is created at the end
         for marker, unique_key in zip(plotly_lines, unique_values):
             fig.add_trace(
                 go.Scatter(
                     x=dataframe["total_timesteps"].iloc[: end_episode[idx]],
+                    # window is 100 to calculate a crude percentage approximation
                     y=(dataframe["episode_end_reason"] == unique_key)
                     .iloc[: end_episode[idx]]
                     .rolling(100, 0)
@@ -177,6 +187,7 @@ def plot_episode_log(
                 row=4,
                 col=1,
             )
+        # fith subplot
         fig.add_trace(
             go.Scatter(
                 x=dataframe["total_timesteps"].iloc[: end_episode[idx]],
@@ -193,6 +204,7 @@ def plot_episode_log(
             row=5,
             col=1,
         )
+        # sixth subplot
         fig.add_trace(
             go.Scatter(
                 x=dataframe["total_timesteps"].iloc[: end_episode[idx]],
@@ -207,6 +219,7 @@ def plot_episode_log(
             col=1,
         )
 
+    # create end reason legend
     for marker, unique_key in zip(plotly_lines, unique_values):
         fig.add_trace(
             go.Scatter(
@@ -227,11 +240,13 @@ def plot_episode_log(
             col=1,
         )
 
+    # adapt figure size
     fig.update_traces(line=dict(width=0.6))
     if window_size[0] == "auto":
         fig.update_layout(autosize=True)
     else:
         fig.update_layout(height=window_size[0], width=window_size[1])
+    # update axis labels
     fig.update_xaxes(title_text="Total time steps", row=6, col=1)
     fig.update_yaxes(title_text="Episode reward", row=1, col=1)
     fig.update_yaxes(title_text="Steps<br>per episode", row=2, col=1)
@@ -240,7 +255,7 @@ def plot_episode_log(
     fig.update_yaxes(title_text="Seconds<br>per step [s]", row=5, col=1)
     fig.update_yaxes(title_text="Wall time", row=6, col=1)
 
-    # Export the plot as html
+    # Export the plot as the suffix or as "episode_log.html"
     suffix = export_path.suffix
     if suffix == ".html":
         fig.write_html(export_path)
@@ -251,7 +266,7 @@ def plot_episode_log(
     else:
         if not (export_path.parent / "episode_log.html").exists():
             print(
-                "File path suffix is not html nor is the file path a directory. "
+                "File path suffix is not known nor is the file path a directory. "
                 f"Saving to {export_path.parent / 'episode_log.html'}"
             )
             fig.write_html(export_path.parent / "episode_log.html")


### PR DESCRIPTION
Visualize the episode log in plotly.

It gives the option to automatically create a plot of the experiment after it is done. Or to create one with multiple experiments for easy and quick comparison. For the command line options please check with `releso help` and `releso visualize help`.

The functionality can also be used inside a script by importing and calling the function `releso.util.visualization.plot_episode_log`. Please check the code documentation for how the function is used.

It follows very closely to the format that was shown in the published Paper [Fricke2023] (see Readme) and is available already for `matplotlib` by request to the author. The `matplotlib` version is nice since it can directly export it in `pgf` format to be included in `latex` based papers. The `plotly` version can not do it but can produce interactive graphics which enable better development progress.

Image (non-interactive) of `plotly` plot as an example.
![image](https://github.com/user-attachments/assets/a6ddc803-529e-4173-a97f-0459cd61d62f)

Interactive possibilities, by `plotly`: Zoom into regions of interest, hide specific experiments (example has 4 hidden to declutter the image), etc. 