### PR TITLE
Visualisation option for step log files

### DIFF
--- a/releso/__main__.py
+++ b/releso/__main__.py
@@ -142,11 +142,13 @@ def main(args) -> pathlib.Path:
 def entry():
     """Entry point if this package is called directly from the command line."""
     parser = argparse.ArgumentParser(
-        description="Reinforcement Learning based Shape Optimization (releso) "
-        "Toolbox. This python program loads a problem definition and trains "
-        "an RL agent to solve the resulting problem. Furthermore a trained "
-        "agent can be evaluated or data gathered during a training visualized. "
-        f"The package version is: {__version__}."
+        description=(
+            "Reinforcement Learning based Shape Optimization (releso) Toolbox. "
+            "This python program loads a problem definition and trains an RL "
+            "agent to solve the resulting problem. Furthermore a trained "
+            "agent can be evaluated or data gathered during a training "
+            f"visualized. The package version is: {__version__}."
+        )
     )
     parser.add_argument(
         "--version",
@@ -167,26 +169,30 @@ def entry():
     )
     parser_run.add_argument(
         "-i",
-        "--input_file",
+        "--input-file",
         action="store",
         required=True,
         help="Path to the json file storing the optimization definition.",
     )
     parser_run.add_argument(
         "-v",
-        "--validate_only",
+        "--validate-only",
         action="store_true",
-        help="If this is set only validation on this configuration is run. "
-        "Please configure the validation object in the json file so that this "
-        "option can be correctly executed.",
+        help=(
+            "If this is set only validation on this configuration is run. "
+            "Please configure the validation object in the json file so that "
+            "this option can be correctly executed.",
+        )
     )
     parser_run.add_argument(
         "-j",
-        "--json_only",
+        "--json-only",
         dest="json_validate",
         action="store_true",
-        help="If this is set only the json validation is performed, nothing "
-        "else.",
+        help=(
+            "If this is set only the json validation is performed, nothing "
+            "else."
+        ),
     )
     parser_visualize = sub_parser.add_parser(
         "visualize",
@@ -200,7 +206,7 @@ def entry():
     visualize_shared_args = argparse.ArgumentParser(add_help=False)
     visualize_shared_args.add_argument(
         "-e",
-        "--export_path",
+        "--export-path",
         type=pathlib.Path,
         default="./",
         help=(
@@ -227,7 +233,7 @@ def entry():
         required=True
     )
     parser_visualize_episodelog = sub_parser_visualize.add_parser(
-        "episode_log",
+        "episode-log",
         parents=[visualize_shared_args],
         help=(
             "Visualize training progress. List all folders you want to "
@@ -245,16 +251,21 @@ def entry():
         type=pathlib.Path,
         nargs="*",
         required=True,
-        help="Visualize given training episode logs. You can also use "
-        "wildcard arguments '*' or '?' at least on some systems.",
+        help=(
+            "Visualize given training episode logs. You can also use wildcard "
+            "arguments '*' or '?' at least on some systems."
+        )
+        ,
     )
     parser_visualize_episodelog.add_argument(
         "-w",
         "--window",
         type=check_positive,
         default=5,
-        help="Episode visualization uses windowing to smooth the graph. Set "
-        "the window length. Defaults to 5.",
+        help=(
+            "Episode visualization uses windowing to smooth the graph. Set "
+            "the window length. Defaults to 5."
+        ),
     )
     parser_visualize_episodelog.add_argument(
         "-c",
@@ -269,7 +280,7 @@ def entry():
         )
     )
     parser_visualize_steplog = sub_parser_visualize.add_parser(
-        "step_log",
+        "step-log",
         parents=[visualize_shared_args],
         help=(
             "Visualize the strategy of the agent employed in each episode. "
@@ -283,43 +294,52 @@ def entry():
         "--logfile",
         type=pathlib.Path,
         required=True,
-        help="Visualize a given training step log to analyze the strategy " \
-        "learned by an agent in a specific run."
+        help=(
+            "Visualize a given training step log to analyze the strategy "
+            "learned by an agent in a specific run."
+        )
     )
     parser_visualize_steplog.add_argument(
         "-i",
-        "--episode_id",
+        "--episode-id",
         type=check_positive,
         default=0,
-        help="ID of the environment whose data is supposed to be visualized "
-        "(only relevant for multi-environment trainings). Defaults to 0."
+        help=(
+            "ID of the environment whose data is supposed to be visualized "
+            "(only relevant for multi-environment trainings). Defaults to 0."
+        )
     )
     parser_visualize_steplog.add_argument(
         "-f",
-        "--from_episode",
+        "--from-episode",
         type=check_positive,
         default=0,
-        help="Starting episode of the interactive visualization. "
-        "Defaults to 0.",
+        help=(
+            "Starting episode of the interactive visualization. Defaults to 0."
+        ),
     )
     parser_visualize_steplog.add_argument(
         "-n",
-        "--nepisodes",
+        "--n-episodes",
         type=check_positive,
         default=1,
-        help="Select the number of episodes to be included in each visualization. "
-        "Defaults to 1 which means that every episode between from_episode and "
-        "until_episode will be visualized. Set to a larger value to include"
-        "less episodes in the visualization.",
+        help=(
+            "Select the number of episodes to be included in each visualization. "
+            "Defaults to 1 which means that every episode between from_episode "
+            "and until_episode will be visualized. Set to a larger value to "
+            "include less episodes in the visualization."
+        ),
     )
     parser_visualize_steplog.add_argument(
         "-u",
-        "--until_episode",
+        "--until-episode",
         type=check_positive,
         default=None,
-        help="Final episode of the interactive visualization. "
-        "Defaults to None, which means that all episodes after the chosen "
-        "starting one will be visualized.",
+        help=(
+            "Final episode of the interactive visualization. Defaults to None, "
+            "which means that all episodes after the chosen starting one will "
+            "be visualized."
+        ),
     )
     args = parser.parse_args()
     if args.version:

--- a/releso/__main__.py
+++ b/releso/__main__.py
@@ -60,6 +60,28 @@ def check_positive(value) -> int:
     return value
 
 
+def check_positive_or_zero(value) -> int:
+    """Checks if the provided value is positive or zero.
+
+
+    Args:
+        value (Any): Value to be cast to integer.
+
+    Raises:
+        argparse.ArgumentTypeError: Throws error if the value is not positive
+            or zero.
+
+    Returns:
+        int: checked value
+    """
+    value = int(value)
+    if value < 0:
+        raise argparse.ArgumentTypeError(
+            "Provided value is not positive or zero."
+        )
+    return value
+
+
 def check_window_size(value) -> Union[tuple[int, int], Literal["auto"]]:
     """Check window check for error.
 
@@ -308,8 +330,8 @@ def entry():
     )
     parser_visualize_steplog.add_argument(
         "-i",
-        "--episode-id",
-        type=check_positive,
+        "--environment-id",
+        type=check_positive_or_zero,
         default=0,
         help=(
             "ID of the environment whose data is supposed to be visualized "
@@ -319,7 +341,7 @@ def entry():
     parser_visualize_steplog.add_argument(
         "-f",
         "--from-episode",
-        type=check_positive,
+        type=check_positive_or_zero,
         default=0,
         help=(
             "Starting episode of the interactive visualization. Defaults to 0."
@@ -331,9 +353,9 @@ def entry():
         type=check_positive,
         default=1,
         help=(
-            "Select the number of episodes to be included in each visualization. "
-            "Defaults to 1 which means that every episode between from_episode "
-            "and until_episode will be visualized. Set to a larger value to "
+            "Select the amount of episodes skipped between visualized episodes."
+            " Defaults to 1 which means that every episode between from_episode"
+            " and until_episode will be visualized. Set to a larger value to "
             "include less episodes in the visualization."
         ),
     )
@@ -366,7 +388,7 @@ def entry():
         if len(figure_size) == 1:
             figure_size = figure_size[0]
         # Visualize contents of episode_log.csv
-        if args.visualization_mode == "episode_log":
+        if args.visualization_mode == "episode-log":
             folders_to_process: list = [
                 folder.resolve() for folder in args.folders
             ]
@@ -384,10 +406,10 @@ def entry():
             )
             export_figure(fig, args.export_path, "episode_log.html")
         # Visualize contents of step_log.jsonl
-        else:  # args.visualization_mode == "step_log"
+        elif args.visualization_mode == "step-log":
             fig = plot_step_log(
                 args.logfile.resolve(),
-                args.episode_id,
+                args.environment_id,
                 episode_start=args.from_episode,
                 episode_end=args.until_episode,
                 episode_step=args.n_episodes,
@@ -395,6 +417,13 @@ def entry():
             )
             # Export the plot as the suffix or as "steplog_plot.html"
             export_figure(fig, args.export_path, "steplog_plot.html")
+        else:
+            print(
+                f"Unknown visualization mode: {args.visualization_mode}. "
+                "Please choose between 'episode-log' and 'step-log'."
+            )
+            parser.print_help()
+            exit(1)
     else:
         parser.print_help()
         exit(1)

--- a/releso/__main__.py
+++ b/releso/__main__.py
@@ -20,7 +20,8 @@ import torch
 
 from releso.__version__ import __version__
 from releso.base_parser import BaseParser
-from releso.util.visualization import plot_episode_log, plot_step_log
+from releso.util.visualization import export_figure, plot_episode_log, \
+    plot_step_log
 
 try:
     import splinepy
@@ -367,24 +368,25 @@ def entry():
                 folders_to_process.append(run_folder)
             folder_dict = {folder.stem: folder for folder in folders_to_process}
 
-            plot_episode_log(
+            fig = plot_episode_log(
                 folder_dict,
-                args.export_path,
                 args.window,
                 window_size=figure_size,
                 cut_off_point=args.cut_off_point,
             )
+            export_figure(fig, args.export_path, "episode_log.html")
         # Visualize contents of step_log.jsonl
         else: # args.visualization_mode == "step_log"
-            plot_step_log(
+            fig = plot_step_log(
                 args.logfile.resolve(),
-                args.export_path,
                 args.episode_id,
                 episode_start=args.from_episode,
                 episode_end=args.until_episode,
-                step=args.xsteps,
+                episode_step=args.n_episodes,
                 figure_size=figure_size,
             )
+            # Export the plot as the suffix or as "steplog_plot.html"
+            export_figure(fig, args.export_path, "steplog_plot.html")
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/releso/__main__.py
+++ b/releso/__main__.py
@@ -291,12 +291,22 @@ def entry():
         "Defaults to 0.",
     )
     parser_visualize_steplog.add_argument(
+        "-n",
+        "--nepisodes",
+        type=check_positive,
+        default=1,
+        help="Select the number of episodes to be included in each visualization. "
+        "Defaults to 1 which means that every episode between from_episode and "
+        "until_episode will be visualized. Set to a larger value to include"
+        "less episodes in the visualization.",
+    )
+    parser_visualize_steplog.add_argument(
         "-u",
         "--until_episode",
         type=check_positive,
         default=None,
         help="Final episode of the interactive visualization. "
-        "Defaults to None, which means that all episodes after the chosen " \
+        "Defaults to None, which means that all episodes after the chosen "
         "starting one will be visualized.",
     )
     args = parser.parse_args()
@@ -339,6 +349,8 @@ def entry():
                 args.episode_id,
                 episode_start=args.from_episode,
                 episode_end=args.until_episode,
+                step=args.xsteps,
+                figure_size=figure_size,
             )
 
 

--- a/releso/__main__.py
+++ b/releso/__main__.py
@@ -14,6 +14,7 @@ from typing import Literal, Union
 
 import gymnasium
 import hjson
+import numpy as np
 import stable_baselines3
 import torch
 
@@ -255,7 +256,18 @@ def entry():
         help="Episode visualization uses windowing to smooth the graph. Set "
         "the window length. Defaults to 5.",
     )
-    # subparser_visualize_steplog = parser_visualize.add_subparsers()
+    parser_visualize_episodelog.add_argument(
+        "-c",
+        "--cut-off-point",
+        type=check_positive,
+        default=np.iinfo(int).max,
+        help=(
+            "Cut off point for the visualization (in timesteps). If set, the "
+            "visualization will exclude all timesteps after the specified "
+            "cutoff point. Defaults to np.iinfo(int).max, which means that all "
+            "timesteps will be included."
+        )
+    )
     parser_visualize_steplog = sub_parser_visualize.add_parser(
         "step_log",
         parents=[visualize_shared_args],
@@ -340,6 +352,7 @@ def entry():
                 args.export_path,
                 args.window,
                 window_size=figure_size,
+                cut_off_point=args.cut_off_point,
             )
         # Visualize contents of step_log.jsonl
         else: # args.visualization_mode == "step_log"

--- a/releso/__version__.py
+++ b/releso/__version__.py
@@ -3,4 +3,4 @@
 Current version.
 """
 
-__version__ = "0.1.4.dev2"
+__version__ = "0.2.0.dev1"

--- a/releso/__version__.py
+++ b/releso/__version__.py
@@ -3,4 +3,4 @@
 Current version.
 """
 
-__version__ = "0.1.4.dev1"
+__version__ = "0.1.4.dev2"

--- a/releso/base_parser.py
+++ b/releso/base_parser.py
@@ -129,6 +129,7 @@ class BaseParser(BaseModel):
                 episode_log_location=self.save_location / "episode_log.csv",
                 verbose=1,
                 update_n_episodes=self.episode_log_update,
+                logger=self.get_logger(),
             ),
         ]
 
@@ -138,7 +139,8 @@ class BaseParser(BaseModel):
                     step_log_location=self.save_location / "step_log.jsonl",
                     verbose=1,
                     update_n_steps=self.step_log_update,
-                    step_log_info=self.step_log_info,
+                    log_infos=self.step_log_info,
+                    logger=self.get_logger(),
                 ),
             )
 

--- a/releso/base_parser.py
+++ b/releso/base_parser.py
@@ -72,6 +72,9 @@ class BaseParser(BaseModel):
     #: higher will lower the computational overhead. Defaults to 0 which
     #: triggers the output after every episode.
     step_log_update: conint(ge=0) = 0
+    #: Flag indicating whether the step_log should also contain the
+    #: information of the environment step. Defaults to False.
+    step_log_info: bool = False
 
     # internal objects
     #: Holds the trainable agent for the RL use case. The
@@ -135,6 +138,7 @@ class BaseParser(BaseModel):
                     step_log_location=self.save_location / "step_log.jsonl",
                     verbose=1,
                     update_n_steps=self.step_log_update,
+                    step_log_info=self.step_log_info,
                 ),
             )
 

--- a/releso/callback.py
+++ b/releso/callback.py
@@ -200,7 +200,7 @@ class StepLogCallback(BaseCallback):
             from stable_baselines3.common.logger import configure
 
             self._logger = configure(
-                str(self.episode_log_location.parent / "episode_log.log"),
+                str(self.step_log_location.parent / "episode_log.log"),
                 ["stdout", "csv"],
             )
         self._logger.info(

--- a/releso/callback.py
+++ b/releso/callback.py
@@ -160,6 +160,7 @@ class StepLogCallback(BaseCallback):
         step_log_location: Path,
         verbose: int = 0,
         update_n_steps: int = 0,
+        log_infos: bool = False,
     ):
         """Constructor for the Callback using SB3 interface.
 
@@ -168,6 +169,8 @@ class StepLogCallback(BaseCallback):
             verbose (int, optional): Verbosity of the callback. Defaults to 0.
             update_every (int, optional): Update the step log file every n
             steps. Defaults to 0 which triggers the update after every episode.
+            log_infos (bool, optional): Whether to log the infos. Defaults to
+            False.
         """
         super().__init__(verbose)
         self.step_log_location: Path = step_log_location
@@ -175,8 +178,16 @@ class StepLogCallback(BaseCallback):
         self.current_episodes: list[int] = []
         self.update_n_episodes: int = update_n_steps
         self.first_export: bool = True
-        self.current_max_episodes: int = 0
-
+	self.current_max_episodes: int = 0        
+	self.log_infos: bool = log_infos
+        self.logger.info(
+            (
+                "The StepLogCallback should only be used for debugging purposes"
+                " and only for use-cases with a smallish observation space."
+                " Otherwise it will create a lot of data and slow down the"
+                " training process. Use with caution!"
+            )
+        )
         self._reset_internal_storage()
 
     def _reset_internal_storage(self) -> None:
@@ -246,7 +257,10 @@ class StepLogCallback(BaseCallback):
         self.actions.append(actions)
         self.new_obs.append(new_obs)
         self.rewards.append(rewards)
-        self.infos.append(infos)
+
+        if self.log_infos:
+            infos = self.locals["infos"]  # Additional information
+            self.infos.append(infos)
 
         done_export = False
         # Check if the environment has completed an episode

--- a/releso/util/types.py
+++ b/releso/util/types.py
@@ -4,6 +4,7 @@ This file contains type definitions of commonly used items in this
 framework/package. Mostly RL based here. Some more types can be found in other
 files. Here only types with strictly external contents are created.
 """
+
 from __future__ import annotations
 
 from typing import Dict, Tuple, Union

--- a/releso/util/visualization.py
+++ b/releso/util/visualization.py
@@ -429,7 +429,16 @@ def plot_step_log(
         figure_size (Union[tuple[int, int], Literal['auto']], optional):
           Size of the figure. If 'auto', the size will be adjusted to fit the
           container. Defaults to 'auto'.
-
+        objective_observation (list[tuple[str, tuple[int, int]]]): List of 
+          tuples containing information from which column of the steplog data
+          to extract the information about the objective (each row in a column 
+          generally contains a list of values) and the indices which entries 
+          from that list are supposed to be to extracted.
+        design_variable (list[tuple[str, tuple[int, int]]]): List of tuples 
+          containing information from which column of the steplog data to 
+          extract the information about the design variables (each row in a 
+          column generally contains a list of values) and the indices which 
+          entries from that list are supposed to be to extracted.
     Returns:
         plotly.graph_objects.Figure: A Plotly figure object containing the
           interactive plot for further customization or export.

--- a/releso/util/visualization.py
+++ b/releso/util/visualization.py
@@ -287,16 +287,6 @@ def plot_episode_log(
 
 
 def plot_step_log(
-<<<<<<< HEAD
-    step_log_file,
-    export_path,
-    env_id,
-    episode_start=0,
-    episode_end=None,
-    figure_size: Union[tuple[int, int], Literal["auto"]] = "auto",
-):
-    """ """
-=======
         step_log_file,
         export_path,
         env_id,
@@ -307,7 +297,6 @@ def plot_step_log(
     ):
     """
     """
->>>>>>> 7278870 (Add option to not plot all episodes in the selected range)
     # Load the steplog data from the provided path
     try:
         df_raw = pd.read_json(step_log_file, lines=True)
@@ -342,14 +331,8 @@ def plot_step_log(
     # Filter only the selected episodes
     if episode_end is None:
         episode_end = df["episodes"].max()
-<<<<<<< HEAD
-    df = df[
-        (df["episodes"] >= episode_start) & (df["episodes"] <= episode_end)
-    ]
-=======
     selected_episodes = df["episodes"].unique()[episode_start:(episode_end+1):step]
     df = df[df["episodes"].isin(selected_episodes)]
->>>>>>> 7278870 (Add option to not plot all episodes in the selected range)
 
     # Create the interactive visualization
 

--- a/releso/util/visualization.py
+++ b/releso/util/visualization.py
@@ -429,15 +429,15 @@ def plot_step_log(
         figure_size (Union[tuple[int, int], Literal['auto']], optional):
           Size of the figure. If 'auto', the size will be adjusted to fit the
           container. Defaults to 'auto'.
-        objective_observation (list[tuple[str, tuple[int, int]]]): List of 
+        objective_observation (list[tuple[str, tuple[int, int]]]): List of
           tuples containing information from which column of the steplog data
-          to extract the information about the objective (each row in a column 
-          generally contains a list of values) and the indices which entries 
+          to extract the information about the objective (each row in a column
+          generally contains a list of values) and the indices which entries
           from that list are supposed to be to extracted.
-        design_variable (list[tuple[str, tuple[int, int]]]): List of tuples 
-          containing information from which column of the steplog data to 
-          extract the information about the design variables (each row in a 
-          column generally contains a list of values) and the indices which 
+        design_variable (list[tuple[str, tuple[int, int]]]): List of tuples
+          containing information from which column of the steplog data to
+          extract the information about the design variables (each row in a
+          column generally contains a list of values) and the indices which
           entries from that list are supposed to be to extracted.
     Returns:
         plotly.graph_objects.Figure: A Plotly figure object containing the

--- a/releso/util/visualization.py
+++ b/releso/util/visualization.py
@@ -3,18 +3,10 @@ from typing import Literal, Union
 
 import numpy as np
 import pandas as pd
+import plotly.graph_objects as go
 from pandas.errors import EmptyDataError
-
-from releso.util.module_import_raiser import ModuleImportRaiser
-
-try:
-    import plotly
-    import plotly.graph_objects as go
-    from plotly.subplots import make_subplots
-except ModuleNotFoundError:
-    go = ModuleImportRaiser("plotly")
-    make_subplots = ModuleImportRaiser("plotly")
-
+from plotly.graph_objects import Figure
+from plotly.subplots import make_subplots
 
 plotly_colors = [
     "red",
@@ -32,10 +24,10 @@ plotly_lines = ["solid", "dash", "dot", "dashdot"]
 
 
 def export_figure(
-        fig: plotly.graph_objs.Figure,
-        export_path: pathlib.Path,
-        default_filename: str
-    ) -> None:
+    fig: Figure,
+    export_path: pathlib.Path,
+    default_filename: str,
+) -> None:
     """Exports a given figure to a specified path.
     The function checks the file extension of the export path and saves the
     figure accordingly. If the path is a directory, it saves the figure with
@@ -76,33 +68,34 @@ def plot_episode_log(
     window: int = 5,
     window_size: Union[tuple[int, int], Literal["auto"]] = "auto",
     cut_off_point: int = np.iinfo(int).max,
-) -> plotly.graph_objs.Figure:
+) -> Figure:
     """Plot one or multiple episodes to check out the training progress.
 
     This function can already be called once the first results are in the
-     episode log file, to check out progress during training. But, in general,
-     this function is normally used to compare different runs to see
-     differences in the learning progress. In general all values are plotted
-     over the total number of steps taken during the training. The following
-     variables are shown:
+    episode log file, to check out progress during training. But, in general,
+    this function is normally used to compare different runs to see
+    differences in the learning progress. In general all values are plotted
+    over the total number of steps taken during the training. The following
+    variables are shown:
 
     1. Episode reward - Best used to see if the training is progressing
     2. Steps per Episode - Here you can see if the number of steps to solve
-     the environment decreases over time.
+       the environment decreases over time.
     3. Mean step reward - The higher the better each action actually is.
-     (Calculated value episode_reward/steps_per_episode)
+       (Calculated value episode_reward/steps_per_episode)
     4. Episode End Reason - For each run multiple lines to show why the
-     episode was terminated. !ATTENTION! the window here is 100 to calculate a
-     crude percentage.
+       episode was terminated. !ATTENTION! the window here is 100 to calculate a
+       crude percentage.
     5. Seconds per Step - Time each step took to compute. Should not have much
-     variation in general. But use case specific can have differences.
+       variation in general. But use case specific can have differences.
     6. Wall time - How much time did elapse to this time step. (Integral of
-      previous plot).
+       previous plot).
+
 
     To check out the training I like to look at all the plots at once to see if
-     there is anything that should concern me. For publishing most values have
-     no informational gain so feel free to adapt (Remove certain sub plot, etc)
-      the function.
+    there is anything that should concern me. For publishing most values have
+    no informational gain so feel free to adapt (Remove certain sub plot, etc)
+    the function.
 
     Author: Clemens Fricke (clemens.david.fricke@tuwien.ac.at)
 
@@ -305,13 +298,13 @@ def plot_episode_log(
 
 
 def plot_step_log(
-        step_log_file: pathlib.Path,
-        env_id: int,
-        episode_start: int = 0,
-        episode_end: int = None,
-        episode_step: int = 1,
-        figure_size: Union[tuple[int, int], Literal["auto"]] = "auto",
-    ) -> plotly.graph_objects.Figure:
+    step_log_file: pathlib.Path,
+    env_id: int,
+    episode_start: int = 0,
+    episode_end: int = None,
+    episode_step: int = 1,
+    figure_size: Union[tuple[int, int], Literal["auto"]] = "auto",
+) -> Figure:
     """Plot the step log data of a single run for multiple episodes.
 
     This function is used to visualize the step log data of a single run
@@ -320,11 +313,11 @@ def plot_step_log(
     It creates an interactive plot with two subplots:
 
     1. The first subplot shows the reward and objective value over the number
-    of timesteps within the current episode.
+       of timesteps within the current episode.
     2. The second subplot shows the values of the design variables (observations)
-    over the number of timesteps within the current episode.
-    The plot is interactive, allowing users to select different episodes via a
-    slider to view the corresponding data.
+       over the number of timesteps within the current episode.
+       The plot is interactive, allowing users to select different episodes via a
+       slider to view the corresponding data.
 
     Since plotly does not recompute data when the user interacts with the
     plot, the data for all episodes is precomputed and stored in the figure.
@@ -347,7 +340,7 @@ def plot_step_log(
           Defaults to None.
         episode_step (int, optional): Step size for selecting episodes.
           Defaults to 1, which means that every episode between the starting
-          and final episide are visualized.
+          and final episode are visualized.
         figure_size (Union[tuple[int, int], Literal['auto']], optional):
           Size of the figure. If 'auto', the size will be adjusted to fit the
           container. Defaults to 'auto'.
@@ -356,7 +349,7 @@ def plot_step_log(
         plotly.graph_objects.Figure: A Plotly figure object containing the
           interactive plot for further customization or export.
     """
-    # Load the steplog data from the provided path
+    # Load the step log data from the provided path
     try:
         df_raw = pd.read_json(step_log_file, lines=True)
     except RuntimeError as err:
@@ -390,7 +383,9 @@ def plot_step_log(
     # Filter only the selected episodes
     if episode_end is None:
         episode_end = df["episodes"].max()
-    selected_episodes = df["episodes"].unique()[episode_start:(episode_end+1):episode_step]
+    selected_episodes = df["episodes"].unique()[
+        episode_start : (episode_end + 1) : episode_step
+    ]
     df = df[df["episodes"].isin(selected_episodes)]
 
     # Create the interactive visualization

--- a/releso/util/visualization.py
+++ b/releso/util/visualization.py
@@ -287,6 +287,7 @@ def plot_episode_log(
 
 
 def plot_step_log(
+<<<<<<< HEAD
     step_log_file,
     export_path,
     env_id,
@@ -295,6 +296,18 @@ def plot_step_log(
     figure_size: Union[tuple[int, int], Literal["auto"]] = "auto",
 ):
     """ """
+=======
+        step_log_file,
+        export_path,
+        env_id,
+        episode_start=0,
+        episode_end=None,
+        step=1,
+        figure_size: Union[tuple[int, int], Literal["auto"]] = "auto",
+    ):
+    """
+    """
+>>>>>>> 7278870 (Add option to not plot all episodes in the selected range)
     # Load the steplog data from the provided path
     try:
         df_raw = pd.read_json(step_log_file, lines=True)
@@ -329,9 +342,14 @@ def plot_step_log(
     # Filter only the selected episodes
     if episode_end is None:
         episode_end = df["episodes"].max()
+<<<<<<< HEAD
     df = df[
         (df["episodes"] >= episode_start) & (df["episodes"] <= episode_end)
     ]
+=======
+    selected_episodes = df["episodes"].unique()[episode_start:(episode_end+1):step]
+    df = df[df["episodes"].isin(selected_episodes)]
+>>>>>>> 7278870 (Add option to not plot all episodes in the selected range)
 
     # Create the interactive visualization
 

--- a/releso/util/visualization.py
+++ b/releso/util/visualization.py
@@ -452,7 +452,9 @@ def plot_step_log(
     df_raw["episodes"] = df_raw["episodes"].apply(lambda x: x[env_id])
     df_raw["reward"] = df_raw["rewards"].apply(lambda x: x[env_id])
     df_raw["obs"] = df_raw["new_obs"].apply(lambda x: x[env_id])
-    df_raw["infos"] = df_raw["infos"].apply(lambda x: x[env_id])
+    has_info = "infos" in df_raw.columns
+    if has_info:
+        df_raw["infos"] = df_raw["infos"].apply(lambda x: x[env_id])
 
     # Convert obs vector into columns
     # obs_array = np.vstack(df_raw["obs"].values)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -273,3 +273,14 @@ def basic_verbosity_definition(dir_save_location):
     return {
         "save_location": dir_save_location,
     }
+
+
+@pytest.fixture
+def get_null_logger():
+    import logging
+
+    logger = logging.getLogger("test_logger")
+    logger.setLevel(logging.CRITICAL)
+    null_handler = logging.NullHandler()
+    logger.addHandler(null_handler)
+    return logger

--- a/tests/test_callback.py
+++ b/tests/test_callback.py
@@ -6,12 +6,16 @@ from releso.callback import EpisodeLogCallback, StepLogCallback
 
 
 def test_callback_episode_log_callback(
-    dir_save_location, clean_up_provider, provide_dummy_environment
+    dir_save_location,
+    clean_up_provider,
+    get_null_logger,
+    provide_dummy_environment,
 ):
     # this test is not very good, but it is a start
     # TODO: improve this test
     call_back = EpisodeLogCallback(
-        episode_log_location=dir_save_location / "test.csv"
+        episode_log_location=dir_save_location / "test.csv",
+        logger=get_null_logger,
     )
     assert call_back.episode_log_location == dir_save_location / "test.csv"
     assert call_back.episodes == -1
@@ -36,6 +40,7 @@ def test_callback_episode_log_callback(
 def test_callback_step_information_log_callback(
     dir_save_location,
     clean_up_provider,
+    get_null_logger,
     provide_dummy_environment,
     update_n_steps,
 ):
@@ -44,6 +49,8 @@ def test_callback_step_information_log_callback(
     call_back = StepLogCallback(
         step_log_location=dir_save_location / "test.jsonl",
         update_n_steps=update_n_steps,
+        log_infos=True,
+        logger=get_null_logger,
     )
     assert call_back.step_log_location == dir_save_location / "test.jsonl"
     assert call_back.current_episodes == []


### PR DESCRIPTION
With this PR we're introducing native support to visualize step log files. This feature is meant to support the understanding of what an agent learns within the different episodes of a training run by visualising its employed strategy through an investigation of the change in design parameters.

> **Warning:**
> Use this visualisation option carefully: If you include too many episodes in one plot you won't be able to conveniently switch between the different episodes in the resulting figure.

# Developer notes
- I introduced a sub parser hierarchy for processing the command line parameters and marked parameters as `required` where applicable
- invoking releso for training now by default requires the positional argument `run`, i.e., `releso run -i my_config.json`
- with the changes in this PR it is no longer possible to chain an agent training with a subsequent evaluation. This now requires two calls to `releso`
- if desired, I can add an additional option to only visualize every i-th episode