### PR TITLE
Workdir correction

### DIFF
--- a/docs/source/SPOR.rst
+++ b/docs/source/SPOR.rst
@@ -71,3 +71,10 @@ During the configuration if the validation the number of different episodes each
 To help the user in the development of these external task/steps the framework has helper functions in the :doc:`_autosummary/releso.util.reward_helpers` module. These are able to setup the working space of the task with "persistent" memory and the parsing of the communication interface command line options can also be handled via these functions.
 
 Also look at the examples and tests to see how you can use internalized python functions to speed up execution.
+
+Custom Python based SPOR object
+-------------------------------
+
+The framework is able to use custom python based SPOR objects. In most examples ReLeSO is currently used in this is the main way to integrate the external solver and reward calculation.
+
+Use the definition for the :doc:`_autosummary/releso.spor.SPORObjectExternalPythonFunction` to use this functionality. A small example is given :doc:`mini_example`.

--- a/docs/source/SPOR.rst
+++ b/docs/source/SPOR.rst
@@ -75,6 +75,7 @@ Also look at the examples and tests to see how you can use internalized python f
 Custom Python based SPOR object
 -------------------------------
 
-The framework is able to use custom python based SPOR objects. In most examples ReLeSO is currently used in this is the main way to integrate the external solver and reward calculation.
+The framework is able to use custom python based SPOR objects. In most examples ReLeSO is currently used like this. It is the main way to integrate the external solver and reward calculation.
+
 
 Use the definition for the :doc:`_autosummary/releso.spor.SPORObjectExternalPythonFunction` to use this functionality. A small example is given :doc:`mini_example`.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -47,6 +47,7 @@ For guidance on the installation process see :doc:`installation`.
 .. toctree::
    installation
    usage
+   mini_example
    json_schema
    ReLeSO
    SPOR

--- a/docs/source/mini_example.rst
+++ b/docs/source/mini_example.rst
@@ -1,0 +1,208 @@
+======================
+Mini Example
+======================
+
+This minimal example goes through the definition of all required files for the follwing task:
+
+
+The mini example consists of 5 points in space which are movable only in x direction. The goal is to move the points to the maximal x direction. The reward given is dense and consists of the sum of all x coordinates of the points.
+
+In general everything is defined in the *hjson* file. It defines:
+1. **Environment**: Geometry (definition of the actions) and the steps to compute the resulting observations and rewards.
+2. **Agent**: ReLeSO used agents provided by Stable Baselines3.
+3. **General**: Verbosity, number of episodes, number of steps, etc.
+
+As a separate part of the **Environment** the **SPOR** system needs to be discussed. It is the way the user of ReLeSO defines the custom steps to generate the observations and the reward.
+
+Environment
+-----------
+
+
+Geometry
+~~~~~~~~
+
+The first step in the definition of the environment is the definition of the geometry. The geometry defines the actions and some of the observations.
+
+For the example given above the geometry consists of 5 control points, where each can be moved in the y direction between [-3,3]. This can be defined in the *hjson* file as:
+
+
+.. code-block::
+
+    "geometry": {
+        "shape_definition":{
+                "control_points": [
+                    [
+                        {
+                            "current_position": 0.0,
+                            "min_value": -3.0,
+                            "max_value": 3.0,
+                        },
+                        {
+                            "current_position": 0.0
+                        }
+                    ],
+                    [
+                        {
+                            "current_position": 0.0,
+                            "min_value": -3.0,
+                            "max_value": 3.0,
+                        },
+                        {
+                            "current_position": 1.0
+                        }
+                    ],
+                    [
+                        {
+                            "current_position": 0.0,
+                            "min_value": -3.0,
+                            "max_value": 3.0,
+                        },
+                        {
+                            "current_position": 2.0
+                        }
+                    ],
+                    [
+                        {
+                            "current_position": 0.0,
+                            "min_value": -3.0,
+                            "max_value": 3.0,
+                        },
+                        {
+                            "current_position": 3.0
+                        }
+                    ],
+                    [
+                        {
+                            "current_position": 0.0,
+                            "min_value": -3.0,
+                            "max_value": 3.0,
+                        },
+                        {
+                            "current_position": 4.0
+                        }
+                    ],
+                ]
+            },
+        },
+        "discrete_actions": true,
+        "action_based_observation": true,
+    }
+
+The geometry is defined by a shape and by the actions that arise out of this shape. In this case the most basic shape definition ReLeSO offers is used. The shape is only defined by a list of control points.
+In this example each control point exists in two dimensions, where the second dimension is fixed in place. For the first dimension each control point is bounded by [-3,3] with a starting value of 0.0.
+
+The actions that arise out of this shape can either be discrete or continuous actions. In this case discrete actions are chosen. This means that for each movable dimension, for each control point, two actions are defined. One to increase the value and one to decrease the value. This means that his example has 10 actions.
+The step length of the actions are not directly defined here, so it uses default value which means the step length is 1/10 if the range of the parameter. in this case 3/5.
+
+The last item. *actions_based_observation*, defines that the observations should also include the current location of the movable control points.
+
+SPOR
+~~~~
+
+Solver, Postprocessing, Observation and, Reward is where the most customization is needed. Here is where additional observations and the reward is calculated. As this is custom for each Use Case, ReLeSO gives the User tools to implement them themselves. The SPOR system is the way to define these steps. The SPOR system is a list of steps which are executed in order. Each step can be a solver, postprocessing step, observation or reward step or a combination of them. The reward of all steps is combined into one final reward.
+
+For this simple example the SPOR definition could look like this:
+
+.. code-block::
+
+    "spor": {
+        "steps": [
+            {
+                "name": "control_point_sum",
+                "stop_after_error": false,
+                "reward_on_error": -10,
+                "run_on_reset": true,
+                "working_directory": "./",
+                "execution_command": "python",
+                "command_options": [
+                    "examples/dummy.py"
+                ],
+                "use_communication_interface": true,
+                "add_step_information": true
+            }
+        ],
+        "reward_aggregation": "sum"
+    },
+
+
+In this example an external pythons script is used to calculate the reward.
+
+Only a single step is defined. The definition can be categorized into 3 parts:
+**General** The name of the step/task, whether or not to stop and terminate the episode if an error is thrown in this step, if a reward should be applied if the step fails and, whether or not the run the task during a reset step. There are more potential options, but they are not used here since the default values for those are sufficient.
+**User Defined Python Function** First the location where the python script should be run is defined, than that it is a python script that is called (Attention: The script is not called with this command, but first releso tries to load the script and run it "internalized"), the path to the script, and lastly there are two options that define if the communication interface should be used and if the step information should be added to the communication.
+
+**Reward Aggregation** The last part is the aggregation of the reward. In this case the sum of all rewards is used. This means that if multiple steps are defined, the reward of all steps is summed up. If only one step is defined, the reward of that step is used.
+
+As mentioned before if a python file is defined as shown above ReLeSO first tries to load the script and run the function *main()* from it. For this to work this function needs the following signature:
+
+.. code-block:: python
+
+    def main(args, logger, func_data):
+        """
+        Main function of the external task.
+        :param args: A named tuple of the arguments in the communication interface.
+        :param logger: A logger object specifically for this step, defined by releso.
+        :param func_data: An empty object can be used to store persistent data the step needs.
+        :return: The return object includes the reward, observations, done and, info.
+        """
+        # your code
+        return {
+            "reward": reward,
+            "observations": observations,
+            "done": done,
+            "info": info
+        }, func_data
+
+
+In this example the *python* script could look this this:
+
+.. code-block:: python
+
+    from collections import namedtuple
+    from releso.util.reward_helpers import spor_com_parse_arguments
+    import numpy as np
+    from logging import Logger
+    from typing import Optional, Any
+
+    def main(args: namedtuple, logger: Logger, func_data: Optional[Any]):
+        done = False
+        info = {}
+
+        # if add_step_information is not true, the json_object is None
+        # but it is needed to calculate the reward
+        if not args.json_object:
+            print("No additional payload, please provide the needed payload.")
+
+        # setup the func_data object, it is not used in this example
+        if func_data is None:
+            func_data = dict()
+
+        # calculate the reward
+        reward = sum(np.array(args.json_object["info"]["geometry_information"]))
+        logger.info(
+            f"{args.json_object['info']['geometry_information']}, Sum: {sum(np.array(args.json_object['info']['geometry_information']))[0]}, Reward: {reward}"
+            )
+
+        # if reward is very close to the maximum of 15 it is considered as done
+        if reward >= (15-1e-7):
+            logger.warning(f"This is triggered why? : {reward}")
+            reward = 5
+            done = True
+            info["reset_reason"] = "goal_reached"
+        return {
+                "reward": reward,
+                "done": done,
+                "info": info,
+                "observations": []
+            }, func_data
+
+    if __name__ == "__main__":
+        args = spor_com_parse_arguments()
+        if not args.json_object:
+            print("No additional payload, please provide the needed payload.")
+
+        print(main(args, False))
+
+
+
+In general you won't need the last five lines of code since ReLeSO will directly call the *main* function. but it can be used to trouble shoot the script manually (and also is an old way to use the SPOR system).

--- a/docs/source/mini_example.rst
+++ b/docs/source/mini_example.rst
@@ -34,8 +34,8 @@ In the following the environment definition is shown. The geometry and SPOR part
     }
 
 
-The max_timesteps_in_episode defines the maximum number of steps in an episode. If this number is exceeded, the episode is terminated and the reward is set to the value defined in *reward_on_episode_exceeds_max_timesteps*. The default reward value is 0.0.
-multi_processing defines the number of cores that should be used for the environment, this is mostly for MPI applications. Only define something else if you really know what you are doing. The default value is 1 core.
+The ``max_timesteps_in_episode`` defines the maximum number of steps in an episode. If this number is exceeded, the episode is terminated and the reward is set to the value defined in ``reward_on_episode_exceeds_max_timesteps``. The default reward value is 0.0.
+``multi_processing`` defines the number of cores that should be used for the environment, this is mostly for MPI applications. Only define something else if you really know what you are doing. The default value is 1 core.
 
 
 Geometry
@@ -43,7 +43,7 @@ Geometry
 
 The first step in the definition of the environment is the definition of the geometry. The geometry defines the actions and some of the observations.
 
-For the example given above the geometry consists of 5 control points, where each can be moved in the x direction between [-3,3]. This can be defined in the *hjson* file as:
+For the example given above the geometry consists of 5 control points, where each can be moved in the x direction between :math:`[-3,3]`. This can be defined in the *hjson* file as:
 
 
 .. code-block::
@@ -109,12 +109,12 @@ For the example given above the geometry consists of 5 control points, where eac
     }
 
 The geometry is defined by a shape and by the actions that arise out of this shape. In this case the most basic shape definition ReLeSO offers is used. The shape is only defined by a list of control points.
-In this example each control point exists in two dimensions, where the second dimension is fixed in place. For the first dimension each control point is bounded by [-3,3] with a starting value of 0.0.
+In this example each control point exists in two dimensions, where the second dimension is fixed in place. For the first dimension each control point is bounded by :math:`[-3,3]` with a starting value of 0.0.
 
 The actions that arise out of this shape can either be discrete or continuous actions. In this case discrete actions are chosen. This means that for each movable dimension, for each control point, two actions are defined. One to increase the value and one to decrease the value. This means that his example has 10 actions.
 The step length of the actions are not directly defined here, so it uses default value which means the step length is 1/10 of the range of the parameter, in this case 3/5.
 
-The last item *actions_based_observation*, defines that the observations should also include the current location of the movable control points.
+The last item ``actions_based_observation``, defines that the observations should also include the current location of the movable control points.
 
 SPOR
 ~~~~
@@ -146,11 +146,11 @@ In this example an external python script is used to calculate the reward.
 
 Only a single step is defined. The definition can be categorized into 3 parts:
 **General** The name of the step/task, whether or not to stop and terminate the episode if an error is thrown in this step, if a reward should be applied if the step fails and, whether or not the run the task during a reset step. There are more potential options, but they are not used here since the default values for those are sufficient.
-**User Defined Python Function** First the location where the python script should be run is defined, then that it is a python script that is called (Attention: The script is not called with this command, but first releso tries to load a specific *main()* function from the script (see below) and run it "internalized"), the path to the script, and lastly there are two options that define if the communication interface should be used and if the step information should be added to the communication.
+**User Defined Python Function** First the location where the python script should be run is defined, then that it is a python script that is called (Attention: The script is not called with this command, but first releso tries to load a specific ``main()`` function from the script (see below) and run it "internalized"), the path to the script, and lastly there are two options that define if the communication interface should be used and if the step information should be added to the communication.
 
 **Reward Aggregation** The last part is the aggregation of the reward. In this case the sum of all rewards is used. This means that if multiple steps are defined, the reward of all steps is summed up. If only one step is defined, the reward of that step is used.
 
-As mentioned before if a python file is defined as shown above ReLeSO first tries to load the script and run the function *main()* from it. For this to work this function needs the following signature:
+As mentioned before if a python file is defined as shown above ReLeSO first tries to load the script and run the function ``main()`` from it. For this to work this function needs the following signature:
 
 .. code-block:: python
 
@@ -247,7 +247,7 @@ In this example the *python* script could look this this:
 
 
 
-In general you won't need the last 25 lines of code since ReLeSO will directly call the *main* function. but it can be used to trouble shoot the script manually (and also is an old way to use the SPOR system).
+In general you won't need the last 25 lines of code since ReLeSO will directly call the ``main`` function. but it can be used to trouble shoot the script manually (and also is an old way to use the SPOR system).
 
 
 Agent
@@ -255,7 +255,7 @@ Agent
 
 The agent is defined in the *hjson* file. The agent is a standard agent from Stable Baselines3. In this case the PPO agent is used. The only thing that needs to be defined is the type of agent and the parameters for the agent. The parameters are passed directly to the constructor of the agent.
 
-The *tensorboard_log* parameter is used to define the path where the tensorboard logs should be saved. This is not needed, but it is recommended to use it since it helps to debug the agent and the training process.
+The ``tensorboard_log`` parameter is used to define the path where the tensorboard logs should be saved. This is not needed, but it is recommended to use it since it helps to debug the agent and the training process.
 
 .. code-block::
 
@@ -285,6 +285,6 @@ The general part of the *hjson* file defines the number of episodes, the number 
     }
 
 
-The *number_of_timesteps* defines the number of timesteps that should be used for training. The *number_of_episodes* defines the number of episodes that should be used for training. The *save_location* defines the location where the logs should be saved. The *verbosity* defines the verbosity of the logs.
+The ``number_of_timesteps`` defines the number of timesteps that should be used for training. The *number_of_episodes* defines the number of episodes that should be used for training. The *save_location* defines the location where the logs should be saved. The ``verbosity`` defines the verbosity of the logs.
 
 In the full example can be found in the *examples* folder of the ReLeSO repository.

--- a/docs/source/mini_example.rst
+++ b/docs/source/mini_example.rst
@@ -33,52 +33,52 @@ For the example given above the geometry consists of 5 control points, where eac
                 "control_points": [
                     [
                         {
+                            "current_position": 0.0
+                        },
+                        {
                             "current_position": 0.0,
                             "min_value": -3.0,
                             "max_value": 3.0,
-                        },
-                        {
-                            "current_position": 0.0
                         }
                     ],
                     [
-                        {
-                            "current_position": 0.0,
-                            "min_value": -3.0,
-                            "max_value": 3.0,
-                        },
                         {
                             "current_position": 1.0
-                        }
-                    ],
-                    [
+                        },
                         {
                             "current_position": 0.0,
                             "min_value": -3.0,
                             "max_value": 3.0,
-                        },
+                        }
+                    ],
+                    [
                         {
                             "current_position": 2.0
-                        }
-                    ],
-                    [
+                        },
                         {
                             "current_position": 0.0,
                             "min_value": -3.0,
                             "max_value": 3.0,
                         },
+                    ],
+                    [
                         {
                             "current_position": 3.0
-                        }
-                    ],
-                    [
+                        },
                         {
                             "current_position": 0.0,
                             "min_value": -3.0,
                             "max_value": 3.0,
-                        },
+                        }
+                    ],
+                    [
                         {
                             "current_position": 4.0
+                        },
+                        {
+                            "current_position": 0.0,
+                            "min_value": -3.0,
+                            "max_value": 3.0,
                         }
                     ],
                 ]
@@ -196,12 +196,31 @@ In this example the *python* script could look this this:
                 "observations": []
             }, func_data
 
+    # Add option of running the script manually, or with original command line
+    # spor step in ReLeSO.
     if __name__ == "__main__":
         args = spor_com_parse_arguments()
         if not args.json_object:
             print("No additional payload, please provide the needed payload.")
 
-        print(main(args, False))
+        #
+        path = Path(f"{os.getcwd()}/{args.run_id}")
+        path.mkdir(exist_ok=True, parents=True)
+
+        local_variable_store_path = path/"local_variable_store.json"
+        if not path.exists():
+            func_data = {
+                "last_error": 0
+            }
+            write_json(local_variable_store_path, func_data)
+
+        func_data = load_json(local_variable_store_path)
+
+        step_data, func_data = main(args, False, func_data)
+
+        write_json(path, func_data)
+
+        print(step_data)
 
 
 

--- a/docs/source/mini_example.rst
+++ b/docs/source/mini_example.rst
@@ -9,7 +9,7 @@ The mini example consists of 5 points in space which are movable only in x direc
 
 In general everything is defined in the *hjson* file. It defines:
 1. **Environment**: Geometry (definition of the actions) and the steps to compute the resulting observations and rewards.
-2. **Agent**: ReLeSO used agents provided by Stable Baselines3.
+2. **Agent**: ReLeSO uses agents provided by Stable Baselines3.
 3. **General**: Verbosity, number of episodes, number of steps, etc.
 
 As a separate part of the **Environment** the **SPOR** system needs to be discussed. It is the way the user of ReLeSO defines the custom steps to generate the observations and the reward.
@@ -92,14 +92,14 @@ The geometry is defined by a shape and by the actions that arise out of this sha
 In this example each control point exists in two dimensions, where the second dimension is fixed in place. For the first dimension each control point is bounded by [-3,3] with a starting value of 0.0.
 
 The actions that arise out of this shape can either be discrete or continuous actions. In this case discrete actions are chosen. This means that for each movable dimension, for each control point, two actions are defined. One to increase the value and one to decrease the value. This means that his example has 10 actions.
-The step length of the actions are not directly defined here, so it uses default value which means the step length is 1/10 if the range of the parameter. in this case 3/5.
+The step length of the actions are not directly defined here, so it uses default value which means the step length is 1/10 of the range of the parameter, in this case 3/5.
 
-The last item. *actions_based_observation*, defines that the observations should also include the current location of the movable control points.
+The last item *actions_based_observation*, defines that the observations should also include the current location of the movable control points.
 
 SPOR
 ~~~~
 
-Solver, Postprocessing, Observation and, Reward is where the most customization is needed. Here is where additional observations and the reward is calculated. As this is custom for each Use Case, ReLeSO gives the User tools to implement them themselves. The SPOR system is the way to define these steps. The SPOR system is a list of steps which are executed in order. Each step can be a solver, postprocessing step, observation or reward step or a combination of them. The reward of all steps is combined into one final reward.
+Solver, Postprocessing, Observation and, Reward is where the most customization is needed. Here is where additional observations and the reward are calculated. As this is custom for each use case, ReLeSO provides the user with tools to implement them themselves. The SPOR system is the way to define these steps. The SPOR system is a list of steps which are executed in order. Each step can be a solver, postprocessing step, observation or reward step or a combination of them. The reward of all steps is combined into one final reward.
 
 For this simple example the SPOR definition could look like this:
 
@@ -125,11 +125,11 @@ For this simple example the SPOR definition could look like this:
     },
 
 
-In this example an external pythons script is used to calculate the reward.
+In this example an external python script is used to calculate the reward.
 
 Only a single step is defined. The definition can be categorized into 3 parts:
 **General** The name of the step/task, whether or not to stop and terminate the episode if an error is thrown in this step, if a reward should be applied if the step fails and, whether or not the run the task during a reset step. There are more potential options, but they are not used here since the default values for those are sufficient.
-**User Defined Python Function** First the location where the python script should be run is defined, than that it is a python script that is called (Attention: The script is not called with this command, but first releso tries to load the script and run it "internalized"), the path to the script, and lastly there are two options that define if the communication interface should be used and if the step information should be added to the communication.
+**User Defined Python Function** First the location where the python script should be run is defined, then that it is a python script that is called (Attention: The script is not called with this command, but first releso tries to load a specific *main()* function from the script (see below) and run it "internalized"), the path to the script, and lastly there are two options that define if the communication interface should be used and if the step information should be added to the communication.
 
 **Reward Aggregation** The last part is the aggregation of the reward. In this case the sum of all rewards is used. This means that if multiple steps are defined, the reward of all steps is summed up. If only one step is defined, the reward of that step is used.
 

--- a/examples/mini_example/mini_example.hjson
+++ b/examples/mini_example/mini_example.hjson
@@ -1,0 +1,94 @@
+{
+    "agent": {
+        "type": "PPO",
+        "policy": "MlpPolicy",
+        "tensorboard_log": "tensorboard",
+    },
+    "environment": {
+        "geometry": {
+            "shape_definition":{
+                    "control_points": [
+                        [
+                            {
+                                "current_position": 0.0,
+                                "min_value": -3.0,
+                                "max_value": 3.0,
+                            },
+                            {
+                                "current_position": 0.0
+                            }
+                        ],
+                        [
+                            {
+                                "current_position": 0.0,
+                                "min_value": -3.0,
+                                "max_value": 3.0,
+                            },
+                            {
+                                "current_position": 1.0
+                            }
+                        ],
+                        [
+                            {
+                                "current_position": 0.0,
+                                "min_value": -3.0,
+                                "max_value": 3.0,
+                            },
+                            {
+                                "current_position": 2.0
+                            }
+                        ],
+                        [
+                            {
+                                "current_position": 0.0,
+                                "min_value": -3.0,
+                                "max_value": 3.0,
+                            },
+                            {
+                                "current_position": 3.0
+                            }
+                        ],
+                        [
+                            {
+                                "current_position": 0.0,
+                                "min_value": -3.0,
+                                "max_value": 3.0,
+                            },
+                            {
+                                "current_position": 4.0
+                            }
+                        ],
+                    ]
+                },
+            "discrete_actions": true,
+            "action_based_observation": true,
+        },
+        "spor": {
+            "steps": [
+                {
+                    "name": "control_point_sum",
+                    "stop_after_error": false,
+                    "reward_on_error": -10,
+                    "run_on_reset": true,
+                    "working_directory": "./",
+                    "python_file_path": "mini_example.py",
+                    "use_communication_interface": true,
+                    "add_step_information": true
+                }
+            ],
+            "reward_aggregation": "sum"
+        },
+        "max_timesteps_in_episode": 50,
+        "reward_on_episode_exceeds_max_timesteps": 0,
+        "multi_processing": {
+            "number_of_cores": 1
+        }
+    },
+    "number_of_timesteps": 100000,
+    "number_of_episodes": 100000,
+    "save_location": "mini_example_{}/",
+    "verbosity": {
+        "environment": "INFO",
+        "parser": "INFO"
+    }
+}

--- a/examples/mini_example/mini_example.py
+++ b/examples/mini_example/mini_example.py
@@ -1,0 +1,67 @@
+from collections import namedtuple
+from releso.util.reward_helpers import spor_com_parse_arguments, write_json, load_json
+import numpy as np
+from logging import Logger
+from typing import Optional, Any
+from pathlib import Path
+import os
+
+def main(args: namedtuple, logger: Logger, func_data: Optional[Any]):
+    done = False
+    info = {}
+
+    # if add_step_information is not true, the json_object is None
+    # but it is needed to calculate the reward
+    if not args.json_object:
+        print("No additional payload, please provide the needed payload.")
+
+    # setup the func_data object, it is not used in this example
+    if func_data is None:
+        func_data = dict()
+
+    # calculate the reward
+    reward = sum(np.array(args.json_object["info"]["geometry_information"]))[0]
+
+    # if reward is very close to the maximum of 15 it is considered as done
+    if reward >= (15-1e-7):
+        logger.warning(f"This is triggered why? : {reward}")
+        reward = 30
+        done = True
+        info["reset_reason"] = "goal_reached"
+
+    logger.info(
+        f"{args.json_object['info']['geometry_information']}, Sum: {sum(np.array(args.json_object['info']['geometry_information']))[0]}, Reward: {reward}"
+    )
+
+    return {
+            "reward": reward,
+            "done": done,
+            "info": info,
+            "observations": []
+        }, func_data
+
+# Add option of running the script manually, or with original command line
+# spor step in ReLeSO.
+if __name__ == "__main__":
+    args = spor_com_parse_arguments()
+    if not args.json_object:
+        print("No additional payload, please provide the needed payload.")
+
+    #
+    path = Path(f"{os.getcwd()}/{args.run_id}")
+    path.mkdir(exist_ok=True, parents=True)
+
+    local_variable_store_path = path/"local_variable_store.json"
+    if not path.exists():
+        func_data = {
+            "last_error": 0
+        }
+        write_json(local_variable_store_path, func_data)
+
+    func_data = load_json(local_variable_store_path)
+
+    step_data, func_data = main(args, False, func_data)
+
+    write_json(path, func_data)
+
+    print(step_data)

--- a/releso/callback.py
+++ b/releso/callback.py
@@ -229,7 +229,8 @@ class StepLogCallback(BaseCallback):
             "dones"
         ]  # Field indicating if the episode has ended
         if len(self.current_episodes) == 0:
-            self.current_episodes = [idx for idx in range(len(dones))]
+            n_dones = len(dones)
+            self.current_episodes = [idx - n_dones for idx in range(n_dones)]
             self.current_max_episodes = max(self.current_episodes)
         prev_obs = self.model._last_obs  # Old observations
         actions = self.locals["actions"]  # Agent's actions

--- a/releso/spor.py
+++ b/releso/spor.py
@@ -12,6 +12,7 @@ ReLeSO communication protocol.
 A more in depth documentation of the SPOR concept is given here
 :ref:`SPOR Communication Interface <sporcominterface>`
 """
+
 import importlib
 import json
 import os
@@ -277,9 +278,9 @@ class SPORObject(BaseModel):
             for item in self.additional_observations:
                 observations[item.name] = item.get_default_observation()
         else:
-            observations[
-                self.additional_observations.name
-            ] = self.additional_observations.get_default_observation()
+            observations[self.additional_observations.name] = (
+                self.additional_observations.get_default_observation()
+            )
         return observations
 
     def run(
@@ -349,9 +350,11 @@ class SPORObjectExecutor(SPORObject):
     #: interface commandline options including the observations, info, done,
     #: reward
     add_step_information: bool = False
-    #: Path to the directory in which the program should run in helpful for
-    #: programs using relative paths. When {} appear in the string a UUID will
-    #: be inserted for multiprocessing purposes.
+    #: Path to the directory in which the program should run, helpful for
+    #: programs using relative paths. If `{}` are the first characters of the
+    #: path, they will be replaced by the save_location of the current run. If
+    #: `{}` are present in the path, the current environment id will be used to
+    #: replace the placeholder. This is necessary for multiprocessing.
     working_directory: str
 
     # communication_interface_variables
@@ -381,17 +384,22 @@ class SPORObjectExecutor(SPORObject):
         """
         # check if placeholder for multiprocessing is available if not use
         # v to validate directory path
-        path = pathlib.Path(v.split("{}")[0]) if "{}" in v else pathlib.Path(v)
-        if not (path.is_dir() and path.exists()):
-            raise ParserException(
-                "SPORObjectCommandline",
-                "unknown",
-                f"The work_directory path {v} does not exist or is not a"
-                " valid directory."
-                " If you are using the multiprocessing placeholder {}, make "
-                "sure, that the path before the placeholder is valid and "
-                "exist.",
+        if not v.startswith("{}"):
+            path = (
+                pathlib.Path(v.split("{}")[0])
+                if "{}" in v
+                else pathlib.Path(v)
             )
+            if not (path.is_dir() and path.exists()):
+                raise ParserException(
+                    "SPORObjectCommandline",
+                    "unknown",
+                    f"The work_directory path {v} does not exist or is not a"
+                    " valid directory."
+                    " If you are using the multiprocessing placeholder {}, make "
+                    "sure, that the path before the placeholder is valid and "
+                    "exists.",
+                )
         return v
 
     @validator("add_step_information")
@@ -437,24 +445,45 @@ class SPORObjectExecutor(SPORObject):
             environment_id (UUID4): Id of the environment. This is the working
                 directory.
         """
-        if "{}" in self.working_directory:
+        print(
+            f"Starting: {self.save_location}, {self.working_directory}, {environment_id}"
+        )
+        if self.working_directory.startswith("{}"):
             self.working_directory = self.working_directory.format(
-                environment_id
+                self.save_location, environment_id
+            )
+            pathlib.Path(self.working_directory).expanduser().resolve().mkdir(
+                parents=True, exist_ok=True
             )
             self.get_logger().info(
                 f"Found placeholder for step with name {self.name}. New "
-                f"working directory is {self.working_directory}"
+                f"working directory is {self.working_directory}. Directory was created."
+            )
+        elif "{}" in self.working_directory:
+            self.working_directory = self.working_directory.format(
+                environment_id
             )
 
             # create run folder if necessary
             path = pathlib.Path(self.working_directory).expanduser().resolve()
             if not path.exists():
                 path.mkdir(parents=True, exist_ok=True)
-
+                self.get_logger().info(
+                    f"Found placeholder for step with name {self.name}. New "
+                    f"working directory is {self.working_directory}. "
+                    "Directory was created."
+                )
+            else:
+                self.get_logger().info(
+                    f"Found placeholder for step with name {self.name}. New "
+                    f"working directory is {self.working_directory}. "
+                    "Directory already exists, step will use it."
+                )
             # TODO this is a XNS specific case
             if self.name == "main_solver":  # pragma: no cover
                 shutil.copyfile(path.parent / "xns_multi.in", path / "xns.in")
                 self.get_logger().info("Copying file.....")
+        print("Ending:", self.working_directory)
 
     def get_multiprocessing_prefix(self, core_count: int) -> str:
         """Add commandline prefix for mpi multiprocessor.
@@ -509,16 +538,18 @@ class SPORObjectExecutor(SPORObject):
 
         # collect all parts of the communication interface
         interface_options: List[str] = ["--run_id", str(self._run_id)]
-        interface_options.extend(
-            ["--base_save_location", str(self.save_location)]
-        )
+        interface_options.extend([
+            "--base_save_location",
+            str(self.save_location),
+        ])
         interface_options.extend(["--environment_id", str(environment_id)])
         if reset:
             interface_options.append("--reset")
         if validation_id is not None:
-            interface_options.extend(
-                ["--validation_value", str(validation_id)]
-            )
+            interface_options.extend([
+                "--validation_value",
+                str(validation_id),
+            ])
         if self.add_step_information:
             json_step_information = {
                 "observations": step_information[0],
@@ -527,14 +558,10 @@ class SPORObjectExecutor(SPORObject):
                 "info": step_information[3],
             }
             # print(json_step_information)
-            interface_options.extend(
-                [
-                    "--json_object",
-                    "'"
-                    + json.dumps(json_step_information, cls=JSONEncoder)
-                    + "'",
-                ]
-            )
+            interface_options.extend([
+                "--json_object",
+                "'" + json.dumps(json_step_information, cls=JSONEncoder) + "'",
+            ])
         return interface_options
 
     def spor_com_interface_read(self, output: bytes, step_dict: Dict):
@@ -585,9 +612,9 @@ class SPORObjectExecutor(SPORObject):
                     "observations"
                 ][item.name]
         else:
-            step_dict["observation"][
-                self.additional_observations.name
-            ] = np.array(returned_step_dict["observations"])
+            step_dict["observation"][self.additional_observations.name] = (
+                np.array(returned_step_dict["observations"])
+            )
 
         join_infos(
             step_dict["info"][self.name],
@@ -748,9 +775,9 @@ class SPORObjectPythonFunction(SPORObjectExecutor):
                         "Will stop episode now, due to thrown error."
                     )
                     step_return["done"] = True
-                    step_return["info"][
-                        "reset_reason"
-                    ] = f"ExecutionFailed-{self.name}"
+                    step_return["info"]["reset_reason"] = (
+                        f"ExecutionFailed-{self.name}"
+                    )
                 step_return["reward"] = self.reward_on_error
                 if self.additional_observations is not None:
                     step_return["observation"] = self.get_default_observation(
@@ -1182,26 +1209,26 @@ class SPORObjectCommandLine(SPORObjectExecutor):
                     if (
                         self.name == "main_solver" and int(exit_code) == 137
                     ):  # pragma: no cover # this is a XNS specific case
-                        step_return["info"][
-                            "reset_reason"
-                        ] = f"meshTangled-{self.name}"
+                        step_return["info"]["reset_reason"] = (
+                            f"meshTangled-{self.name}"
+                        )
                     # the main_solver should always have an output only time
                     # no output is generated srun aborted early (hopefully)
                     elif (
                         self.name == "main_solver" and not output
                     ):  # pragma: no cover # this is a cluster specific case
-                        step_return["info"][
-                            "reset_reason"
-                        ] = f"srunError-{self.name}"
+                        step_return["info"]["reset_reason"] = (
+                            f"srunError-{self.name}"
+                        )
                         self.get_logger().warning(
                             "Could not find any output of failed command "
                             "assuming srun/mpi error. Trying to exit training "
                             "now."
                         )
                     else:
-                        step_return["info"][
-                            "reset_reason"
-                        ] = f"ExecutionFailed-{self.name}"
+                        step_return["info"]["reset_reason"] = (
+                            f"ExecutionFailed-{self.name}"
+                        )
                 step_return["reward"] = self.reward_on_error
                 if self.additional_observations is not None:
                     step_return["observation"] = self.get_default_observation(

--- a/releso/spor.py
+++ b/releso/spor.py
@@ -445,9 +445,6 @@ class SPORObjectExecutor(SPORObject):
             environment_id (UUID4): Id of the environment. This is the working
                 directory.
         """
-        print(
-            f"Starting: {self.save_location}, {self.working_directory}, {environment_id}"
-        )
         if self.working_directory.startswith("{}"):
             self.working_directory = self.working_directory.format(
                 self.save_location, environment_id
@@ -483,7 +480,6 @@ class SPORObjectExecutor(SPORObject):
             if self.name == "main_solver":  # pragma: no cover
                 shutil.copyfile(path.parent / "xns_multi.in", path / "xns.in")
                 self.get_logger().info("Copying file.....")
-        print("Ending:", self.working_directory)
 
     def get_multiprocessing_prefix(self, core_count: int) -> str:
         """Add commandline prefix for mpi multiprocessor.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -234,16 +234,14 @@ def basic_spor_definition(dir_save_location):
 @pytest.fixture
 def spor_python_external(basic_spor_definition):
     file_path_prefix = str(pathlib.Path(__file__).parent)
-    basic_spor_definition.update(
-        {
-            "python_file_path": (
-                f"{file_path_prefix}/samples/spor_python_scripts_tests/"
-                "file_exists_has_main.py"
-            ),
-            "use_communication_interface": True,
-            "additional_observations": 3,
-        }
-    )
+    basic_spor_definition.update({
+        "python_file_path": (
+            f"{file_path_prefix}/samples/spor_python_scripts_tests/"
+            "file_exists_has_main.py"
+        ),
+        "use_communication_interface": True,
+        "additional_observations": 3,
+    })
     return basic_spor_definition
 
 

--- a/tests/test_callback.py
+++ b/tests/test_callback.py
@@ -1,7 +1,6 @@
 import pandas as pd
-from stable_baselines3 import PPO
-
 import pytest
+from stable_baselines3 import PPO
 
 from releso.callback import EpisodeLogCallback, StepLogCallback
 
@@ -26,7 +25,9 @@ def test_callback_episode_log_callback(
 
 
 @pytest.mark.parametrize(
-    ["update_n_steps",],
+    [
+        "update_n_steps",
+    ],
     [
         (0,),
         (20,),
@@ -45,7 +46,7 @@ def test_callback_step_information_log_callback(
         update_n_steps=update_n_steps,
     )
     assert call_back.step_log_location == dir_save_location / "test.jsonl"
-    assert call_back.current_episode == 0
+    assert call_back.current_episodes == []
     assert call_back.update_n_episodes == update_n_steps
     assert call_back.first_export
     env = provide_dummy_environment

--- a/tests/test_spor.py
+++ b/tests/test_spor.py
@@ -347,7 +347,7 @@ def test_spor_object_executor(
             False,
         ),
         ("non_existing/folder", "as/", False, False, True),
-        ("existing/folder", "existing/folder/", False, True, False),
+        ("existing/folder/", "existing/folder/", True, True, False),
         (
             "{}/test/{}",
             "test_save_location_please_delete/test/idididid/",

--- a/tests/test_spor.py
+++ b/tests/test_spor.py
@@ -1,5 +1,6 @@
 import copy
 import pathlib
+import shutil
 import uuid
 from collections.abc import Iterable
 from typing import List
@@ -320,9 +321,9 @@ def test_spor_object_executor(
         multi_processor["save_location"] = dir_save_location
         calling_dict["multi_processor"] = multi_processor
     if use_communication_interface:
-        calling_dict[
-            "use_communication_interface"
-        ] = use_communication_interface
+        calling_dict["use_communication_interface"] = (
+            use_communication_interface
+        )
     if add_step_information:
         calling_dict["add_step_information"] = add_step_information
     if error:
@@ -332,6 +333,70 @@ def test_spor_object_executor(
         return
     spor_object = SPORObjectExecutor(**calling_dict)
     assert type(spor_object.multi_processor) is wanted_mp
+
+
+@pytest.mark.parametrize(
+    "working_dir, wanted_result, relative, pre_create, error",
+    [
+        (".", ".", True, False, False),
+        (
+            "{}/test",
+            "test_save_location_please_delete/test/",
+            False,
+            False,
+            False,
+        ),
+        ("non_existing/folder", "as/", False, False, True),
+        ("existing/folder", "existing/folder/", False, True, False),
+        (
+            "{}/test/{}",
+            "test_save_location_please_delete/test/idididid/",
+            False,
+            False,
+            False,
+        ),
+    ],
+)
+def test_spor_object_executor_working_dir(
+    working_dir, wanted_result, relative, pre_create, error, dir_save_location
+):
+    if pre_create:
+        pathlib.Path(working_dir).mkdir(parents=True, exist_ok=True)
+
+    if not relative:
+        wanted_result = str(
+            (
+                pathlib.Path("/".join(str(dir_save_location).split("/")[:-1]))
+                / wanted_result
+            )
+            .resolve()
+            .absolute()
+        )
+
+    calling_dict = {
+        "name": "test",
+        "save_location": dir_save_location,
+        "reward_on_error": 0.0,
+        "multi_processor": {
+            "max_core_count": 1,
+            "save_location": dir_save_location,
+        },
+    }
+    calling_dict["working_directory"] = str(working_dir)
+    if error:
+        with pytest.raises(ValidationError):
+            spor_object = SPORObjectExecutor(**calling_dict)
+            spor_object.setup_working_directory("idididid")
+        return
+    spor_object = SPORObjectExecutor(**calling_dict)
+    spor_object.setup_working_directory("idididid")
+    print(spor_object.working_directory)
+    # if relative:
+    #     assert spor_object.working_directory == wanted_result
+    # else:
+    assert spor_object.working_directory == wanted_result
+    if pre_create:
+        shutil.rmtree(wanted_result)
 
 
 @pytest.mark.parametrize("with_multi_processing", [(True), (False)])


### PR DESCRIPTION
When using SPOR steps, the user is able to define a specific work directory in which the step is supposed to be executed. The current implementation has two drawbacks:

1) Rather inflexible in where the work-dir can be located
2) If you want to create the workdir(s) inside the folder where all the results and logs for the run are stored (experiment folder), it is not possible. Therefore, keeping your folder tree clean is not so easy.

This PR fixes this by adding more options into the work dir definition to enable the creation of multiple work-dirs inside the experiment folder.

Added example in docs for how to create a training.
Added tests for new work-dir functionality.