### PR TITLE
Have multiple shape in a geometry

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import builtins
+import copy
 import pathlib
 
 import gymnasium as gym
@@ -85,7 +86,8 @@ def bspline_shape(dir_save_location):
 
 @pytest.fixture
 def nurbs_shape(bspline_shape, dir_save_location):
-    bspline_shape["weights"] = [
+    nurbs_shape = copy.deepcopy(bspline_shape)
+    nurbs_shape["weights"] = [
         0.1,
         0.2,
         0.3,
@@ -106,7 +108,7 @@ def nurbs_shape(bspline_shape, dir_save_location):
         ),
         0.9,
     ]
-    return bspline_shape
+    return nurbs_shape
 
 
 @pytest.fixture

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -251,8 +251,6 @@ def test_ffd_geometry_init(
 @pytest.mark.parametrize(
     (
         "shape_definition",
-        "action_based",
-        "discrete_action",
         "correct_type",
         "n_action_variables",
         "observation_shape",
@@ -260,55 +258,43 @@ def test_ffd_geometry_init(
     [
         (
             "default_shape",
-            None,
-            None,
             ShapeDefinition,
             2,
             [5, 5],
         ),  # test that default is correct
         (
             ["default_shape", "default_shape"],
-            True,
-            True,
             [ShapeDefinition, ShapeDefinition],
             4,
             [[5, 5], [5, 5]],
         ),
         (
             ["default_shape", "bspline_shape"],
-            False,
-            False,
             [ShapeDefinition, BSplineDefinition],
             20,
             [[5, 5], [2, 2, 2, 2, 2, 2, 2, 2, 2]],
         ),
         (
             ["default_shape", "nurbs_shape"],
-            False,
-            False,
             [ShapeDefinition, NURBSDefinition],
             22,
             [[5, 5], [2, 2, 2, 2, 2, 2, 2, 2, 2, 9]],
         ),
-        # # if nurbs and b splines are mixed the shape is always a nurbs.
-        # (
-        #     ["bspline_shape", "nurbs_shape", "nurbs_shape"],
-        #     None,
-        #     False,
-        #     [NURBSDefinition, NURBSDefinition, NURBSDefinition],
-        #     58,
-        #     [
-        #         [2, 2, 2, 2, 2, 2, 2, 2, 2],
-        #         [2, 2, 2, 2, 2, 2, 2, 2, 2, 9],
-        #         [2, 2, 2, 2, 2, 2, 2, 2, 2, 9],
-        #     ],
-        # ),
+        # if nurbs and b splines are mixed the shape is always a nurbs.
+        (
+            ["bspline_shape", "nurbs_shape", "default_shape"],
+            [BSplineDefinition, NURBSDefinition, ShapeDefinition],
+            40,
+            [
+                [2, 2, 2, 2, 2, 2, 2, 2, 2],
+                [2, 2, 2, 2, 2, 2, 2, 2, 2, 9],
+                [5, 5],
+            ],
+        ),
     ],
 )
 def test_geometry_shape_list(
     shape_definition,
-    action_based,
-    discrete_action,
     correct_type,
     n_action_variables,
     observation_shape,
@@ -327,13 +313,7 @@ def test_geometry_shape_list(
             shape_definition
         )
 
-    if action_based is not None:
-        call_dict["action_based_observation"] = action_based
-    if discrete_action is not None:
-        call_dict["discrete_actions"] = discrete_action
-
     geometry = Geometry(**call_dict)
-
     # correct type of shape definition
     if isinstance(correct_type, list):
         assert isinstance(geometry.shape_definition, list), (


### PR DESCRIPTION
Instead of having to use just one geometry, you can now define a list of geometries.

For example, have a NURBSDefinition and some additional design variables in a ShapeDefinition.