### PR TITLE
Ft: Apply random inital position for incremental approach

### DIFF
--- a/releso/geometry.py
+++ b/releso/geometry.py
@@ -252,6 +252,7 @@ class Geometry(BaseModel):
         rng_gen = np.random.default_rng(seed)
         if self.discrete_actions:
             for action_obj in self._actions:
+                action_obj.reset()
                 min_bins = int(
                     (action_obj.min_value - action_obj.current_position)
                     / action_obj.step
@@ -262,7 +263,6 @@ class Geometry(BaseModel):
                 )
                 random_action = rng_gen.integers(min_bins, max_bins)
                 # Apply the random action
-                action_obj.reset()
                 action_obj.current_position += random_action * action_obj.step
         else:
             random_action = (rng_gen.random((len(self._actions),)) * 2) - 1

--- a/releso/geometry.py
+++ b/releso/geometry.py
@@ -45,7 +45,9 @@ class Geometry(BaseModel):
     #: will be used.
     discrete_actions: bool = True
     #: Whether or not to reset the controllable control point variables to a
-    #: random state (True) or the default original state (False).
+    #: random state (True) or the default original state (False). If
+    #: discrete actions are used this will reset the action values to
+    #: valid discrete values.
     reset_with_random_action_values: bool = False
 
     #: saved list of all available actions
@@ -248,10 +250,24 @@ class Geometry(BaseModel):
             f"seed {str(seed)}"
         )
         rng_gen = np.random.default_rng(seed)
-        random_action = (rng_gen.random((len(self._actions),)) * 2) - 1
-        for new_value, action_obj in zip(random_action, self._actions):
-            action_obj.apply_continuous_action(new_value)
-        return random_action
+        if self.discrete_actions:
+            for action_obj in self._actions:
+                min_bins = int(
+                    (action_obj.min_value - action_obj.current_position)
+                    / action_obj.step
+                )
+                max_bins = int(
+                    (action_obj.max_value - action_obj.current_position)
+                    / action_obj.step
+                )
+                random_action = rng_gen.integers(min_bins, max_bins)
+                # Apply the random action
+                action_obj.reset()
+                action_obj.current_position += random_action * action_obj.step
+        else:
+            random_action = (rng_gen.random((len(self._actions),)) * 2) - 1
+            for new_value, action_obj in zip(random_action, self._actions):
+                action_obj.apply_continuous_action(new_value)
 
 
 class FFDGeometry(Geometry):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,6 +63,14 @@ def default_shape(dir_save_location):
 
 
 @pytest.fixture
+def default_shape_discrete_possible_values():
+    return [
+        [4.0, 4.1, 4.2, 4.3, 4.4, 4.5, 4.6, 4.7, 4.8, 4.9, 5.0],
+        [4.0, 4.1, 4.2, 4.3, 4.4, 4.5, 4.6, 4.7, 4.8, 4.9, 5.0],
+    ]
+
+
+@pytest.fixture
 def bspline_shape(dir_save_location):
     ret_dict = {
         "save_location": dir_save_location,

--- a/tests/test_shape_parameterization.py
+++ b/tests/test_shape_parameterization.py
@@ -94,14 +94,12 @@ def test_variable_location_min_max_location(
 def test_variable_location_is_action(
     current_position, min_value, max_value, is_action, dir_save_location
 ):
-    variable_location = VariableLocation(
-        **{
-            "current_position": current_position,
-            "min_value": min_value,
-            "max_value": max_value,
-            "save_location": dir_save_location,
-        }
-    )
+    variable_location = VariableLocation(**{
+        "current_position": current_position,
+        "min_value": min_value,
+        "max_value": max_value,
+        "save_location": dir_save_location,
+    })
     assert variable_location.is_action() is is_action
 
 
@@ -109,10 +107,11 @@ def test_variable_location_is_action(
     "current_position, min_value, max_value, n_steps, step, expected_step, "
     "error",
     [
-        (0, -1, 1, None, None, 0.2, False),
+        (0, -1, 1, 10, None, 0.2, False),
         (0, -1, 1, None, 0.1, 0.1, False),
         (0, -2, 2, 100, None, 4 / 100, False),
         (0, -2, 2, 100, 0.25, 0.25, False),
+        (-1, -1, 0, 10, None, 0.1, False),
     ],
 )
 def test_variable_location_step_length(
@@ -277,16 +276,14 @@ def test_variable_location_discrete_action(
     expect_position,
     dir_save_location,
 ):
-    variable_location = VariableLocation(
-        **{
-            "current_position": current_position,
-            "min_value": min_value,
-            "max_value": max_value,
-            "n_steps": n_steps,
-            "step": step,
-            "save_location": dir_save_location,
-        }
-    )
+    variable_location = VariableLocation(**{
+        "current_position": current_position,
+        "min_value": min_value,
+        "max_value": max_value,
+        "n_steps": n_steps,
+        "step": step,
+        "save_location": dir_save_location,
+    })
     last_current_position = current_position
     for iteration in iterations:
         last_current_position = variable_location.apply_discrete_action(
@@ -348,16 +345,14 @@ def test_variable_location_continuous_action(
     expect_position,
     dir_save_location,
 ):
-    variable_location = VariableLocation(
-        **{
-            "current_position": current_position,
-            "min_value": min_value,
-            "max_value": max_value,
-            "n_steps": n_steps,
-            "step": step,
-            "save_location": dir_save_location,
-        }
-    )
+    variable_location = VariableLocation(**{
+        "current_position": current_position,
+        "min_value": min_value,
+        "max_value": max_value,
+        "n_steps": n_steps,
+        "step": step,
+        "save_location": dir_save_location,
+    })
     last_current_position = current_position
     for iteration in iterations:
         last_current_position = variable_location.apply_continuous_action(
@@ -429,12 +424,10 @@ def test_variable_location_continuous_action(
         (
             [
                 [
-                    OrderedDict(
-                        {
-                            "current_position": 1,
-                            "save_location": dir_save_location_path(),
-                        }
-                    )
+                    OrderedDict({
+                        "current_position": 1,
+                        "save_location": dir_save_location_path(),
+                    })
                 ]
             ],
             1,
@@ -569,12 +562,10 @@ def test_shape_definition_get_actions(
             point["save_location"] = dir_save_location
             new_cps.append(VariableLocation(**point))
         new_control_points.append(new_cps)
-    shape = ShapeDefinition(
-        **{
-            "control_points": new_control_points,
-            "save_location": dir_save_location,
-        }
-    )
+    shape = ShapeDefinition(**{
+        "control_points": new_control_points,
+        "save_location": dir_save_location,
+    })
     actions = shape.get_actions()
     assert len(actions) == n_actions
 


### PR DESCRIPTION
Previously, it was implemented that the initial position could be randomly chosen inside the action's value ranges. This was done by choosing any real number inside the given ranges. This could also be used for the incremental mode (discrete_actions=True), but it would start the episode at values that were inside the value range but not one of the discrete values accessible from the initial position.

**! BREAKING CHANGE**
Using an incremental approach (discrete_actions=True), the behaviour at the extremes of the range of the actions is changed. Previously, the allowable values were clipped to the range. Now, if the next step would bring me outside of the range, the step is not taken, and no move is made.
